### PR TITLE
feat: add KuFlowDataSource model and extract UUIDUtils

### DIFF
--- a/kuflow-rest/src/main/java/com/kuflow/rest/model/KuFlowBusinessArtifact.java
+++ b/kuflow-rest/src/main/java/com/kuflow/rest/model/KuFlowBusinessArtifact.java
@@ -22,6 +22,7 @@
  */
 package com.kuflow.rest.model;
 
+import com.kuflow.rest.util.UUIDUtils;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -56,12 +57,8 @@ public class KuFlowBusinessArtifact {
     }
 
     public static Optional<KuFlowBusinessArtifact> from(String source) {
-        if (source == null || source.isEmpty()) {
-            return Optional.empty();
-        }
-
-        if (!source.toLowerCase().startsWith(PREFIX)) {
-            LOGGER.debug(String.format("Input string '%s' does not start with the expected prefix '%s'", source, PREFIX));
+        if (source == null || !source.toLowerCase().startsWith(PREFIX)) {
+            LOGGER.debug("Input string '{}' does not start with the expected prefix '{}'", source, PREFIX);
 
             return Optional.empty();
         }
@@ -77,7 +74,7 @@ public class KuFlowBusinessArtifact {
 
             int indexOfEquals = pair.indexOf("=");
             if (indexOfEquals == -1) {
-                LOGGER.debug(String.format("Invalid format in key-value pair '%s' on value '%s' ", pair, source));
+                LOGGER.debug("Invalid format in key-value pair '{}' on value '{}' ", pair, source);
 
                 return Optional.empty();
             }
@@ -90,12 +87,12 @@ public class KuFlowBusinessArtifact {
             keyValueMap.put(key, value);
         }
 
-        UUID id = parseUuid(keyValueMap.remove(METADATA_ID));
-        UUID definitionId = parseUuid(keyValueMap.remove(METADATA_DEFINITION_ID.toLowerCase()));
+        UUID id = UUIDUtils.parseUuid(keyValueMap.remove(METADATA_ID));
+        UUID definitionId = UUIDUtils.parseUuid(keyValueMap.remove(METADATA_DEFINITION_ID.toLowerCase()));
         String title = keyValueMap.remove(METADATA_TITLE);
 
         if (id == null || definitionId == null) {
-            LOGGER.debug(String.format("Wrong format some parts are missing 'id=%s' 'definitionId=%s'", id, definitionId));
+            LOGGER.debug("Wrong format some parts are missing 'id={}' 'definitionId={}'", id, definitionId);
 
             return Optional.empty();
         }
@@ -157,18 +154,6 @@ public class KuFlowBusinessArtifact {
     @Override
     public int hashCode() {
         return Objects.hash(this.source);
-    }
-
-    private static UUID parseUuid(String value) {
-        if (value == null) {
-            return null;
-        }
-
-        try {
-            return UUID.fromString(value);
-        } catch (Exception ex) {
-            return null;
-        }
     }
 
     private static String generateValue(UUID id, UUID definitionId, String title) {

--- a/kuflow-rest/src/main/java/com/kuflow/rest/model/KuFlowDataSource.java
+++ b/kuflow-rest/src/main/java/com/kuflow/rest/model/KuFlowDataSource.java
@@ -28,40 +28,28 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class KuFlowPrincipal {
+public class KuFlowDataSource {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(KuFlowPrincipal.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(KuFlowDataSource.class);
 
-    private static final String PREFIX = "kuflow-principal:";
+    public static final String PREFIX = "kuflow-data-source:";
 
     private static final String METADATA_ID = "id";
-
-    private static final String METADATA_TYPE = "type";
-
     private static final String METADATA_NAME = "name";
 
-    public static KuFlowPrincipal from(UUID id, PrincipalType type) {
-        return from(id, type, null);
+    public static KuFlowDataSource from(UUID id, String name) {
+        String source = generateValue(id, name);
+
+        return new KuFlowDataSource(source, id, name);
     }
 
-    public static KuFlowPrincipal from(UUID id, PrincipalType type, String name) {
-        String source = generateValue(id, type, name);
-
-        return new KuFlowPrincipal(source, id, type, name);
-    }
-
-    public static Optional<KuFlowPrincipal> from(String source) {
-        if (source == null || source.isEmpty()) {
-            return Optional.empty();
-        }
-
-        if (!source.toLowerCase().startsWith(PREFIX)) {
+    public static Optional<KuFlowDataSource> from(String source) {
+        if (source == null || !source.toLowerCase().startsWith(PREFIX)) {
             LOGGER.debug("Input string '{}' does not start with the expected prefix '{}'", source, PREFIX);
 
             return Optional.empty();
@@ -72,6 +60,10 @@ public class KuFlowPrincipal {
         Map<String, String> keyValueMap = new HashMap<>();
 
         for (String pair : keyValuePairs) {
+            if (pair == null || pair.trim().isEmpty()) {
+                continue;
+            }
+
             int indexOfEquals = pair.indexOf("=");
             if (indexOfEquals == -1) {
                 LOGGER.debug("Invalid format in key-value pair '{}' on value '{}' ", pair, source);
@@ -88,45 +80,31 @@ public class KuFlowPrincipal {
         }
 
         UUID id = UUIDUtils.parseUuid(keyValueMap.remove(METADATA_ID));
-        String type = keyValueMap.remove(METADATA_TYPE);
         String name = keyValueMap.remove(METADATA_NAME);
 
-        if (id == null || type == null || name == null) {
-            LOGGER.debug("Wrong format some parts are missing 'id={}' 'type={}' 'name={}'", id, type, name);
+        if (id == null) {
+            LOGGER.debug("Wrong format some parts are missing 'id={}'", id);
 
             return Optional.empty();
         }
 
-        KuFlowPrincipal value = new KuFlowPrincipal(source, id, PrincipalType.fromString(type), name);
-
-        return Optional.of(value);
+        return Optional.of(new KuFlowDataSource(source, id, name));
     }
 
     private final String source;
 
     private final UUID id;
 
-    private final PrincipalType type;
-
     private final String name;
 
-    public KuFlowPrincipal(String source, UUID id, PrincipalType type, String name) {
+    private KuFlowDataSource(String source, UUID id, String name) {
         this.source = source;
         this.id = id;
-        this.type = type;
         this.name = name;
-    }
-
-    public String getSource() {
-        return this.source;
     }
 
     public UUID getId() {
         return this.id;
-    }
-
-    public PrincipalType getType() {
-        return this.type;
     }
 
     public String getName() {
@@ -138,47 +116,18 @@ public class KuFlowPrincipal {
         return this.source;
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
+    private static String generateValue(UUID id, String name) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(PREFIX).append(METADATA_ID).append("=").append(encode(id.toString())).append(";");
+
+        if (name != null) {
+            sb.append(METADATA_NAME).append("=").append(encode(name)).append(";");
         }
-        if (o == null || this.getClass() != o.getClass()) {
-            return false;
-        }
-        KuFlowPrincipal that = (KuFlowPrincipal) o;
 
-        return Objects.equals(this.source, that.source);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(this.source);
-    }
-
-    private static String generateValue(UUID id, PrincipalType type, String name) {
-        return (
-            PREFIX +
-            METADATA_ID +
-            "=" +
-            encode(id.toString()) +
-            ";" +
-            METADATA_TYPE +
-            "=" +
-            encode(type.getValue()) +
-            ";" +
-            METADATA_NAME +
-            "=" +
-            encode(name) +
-            ";"
-        );
+        return sb.toString();
     }
 
     private static String encode(String value) {
-        if (value == null) {
-            return "";
-        }
-
         return URLEncoder.encode(value.trim(), StandardCharsets.UTF_8).replaceAll("\\+", "%20");
     }
 }

--- a/kuflow-rest/src/main/java/com/kuflow/rest/model/KuFlowFile.java
+++ b/kuflow-rest/src/main/java/com/kuflow/rest/model/KuFlowFile.java
@@ -49,12 +49,8 @@ public class KuFlowFile {
     private static final String METADATA_ORIGINAL_NAME = "original-name";
 
     public static Optional<KuFlowFile> from(String source) {
-        if (source == null || source.isEmpty()) {
-            return Optional.empty();
-        }
-
-        if (!source.toLowerCase().startsWith(PREFIX)) {
-            LOGGER.debug(String.format("Input string '%s' does not start with the expected prefix '%s'", source, PREFIX));
+        if (source == null || !source.toLowerCase().startsWith(PREFIX)) {
+            LOGGER.debug("Input string '{}' does not start with the expected prefix '{}'", source, PREFIX);
 
             return Optional.empty();
         }
@@ -66,7 +62,7 @@ public class KuFlowFile {
         for (String pair : keyValuePairs) {
             int indexOfEquals = pair.indexOf("=");
             if (indexOfEquals == -1) {
-                LOGGER.debug(String.format("Invalid format in key-value pair '%s' on value '%s' ", pair, source));
+                LOGGER.debug("Invalid format in key-value pair '{}' on value '{}' ", pair, source);
 
                 return Optional.empty();
             }
@@ -80,22 +76,16 @@ public class KuFlowFile {
         }
 
         String uri = keyValueMap.remove(METADATA_URI);
-
         String type = keyValueMap.remove(METADATA_TYPE);
-
         String name = keyValueMap.remove(METADATA_NAME);
-
         Long size = parseLong(keyValueMap.remove(METADATA_SIZE));
+        String originalName = keyValueMap.remove(METADATA_ORIGINAL_NAME);
 
         if (uri == null || type == null || name == null || size == null) {
-            LOGGER.debug(
-                String.format("Wrong format some parts are missing 'uri=%s' 'type=%s' 'name=%s' 'size=%s'", uri, type, name, size)
-            );
+            LOGGER.debug("Wrong format some parts are missing 'uri={}' 'type={}' 'name={}' 'size={}'", uri, type, name, size);
 
             return Optional.empty();
         }
-
-        String originalName = keyValueMap.remove(METADATA_ORIGINAL_NAME);
 
         KuFlowFile value = new KuFlowFile(source, uri, type, name, size, originalName, keyValueMap);
 

--- a/kuflow-rest/src/main/java/com/kuflow/rest/model/KuFlowGroup.java
+++ b/kuflow-rest/src/main/java/com/kuflow/rest/model/KuFlowGroup.java
@@ -22,6 +22,7 @@
  */
 package com.kuflow.rest.model;
 
+import com.kuflow.rest.util.UUIDUtils;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -29,8 +30,12 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class KuFlowGroup {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(KuFlowGroup.class);
 
     public static final String PREFIX = "kuflow-group:";
 
@@ -47,7 +52,7 @@ public class KuFlowGroup {
     }
 
     public static Optional<KuFlowGroup> from(String source) {
-        if (!source.toLowerCase().startsWith(PREFIX)) {
+        if (source == null || !source.toLowerCase().startsWith(PREFIX)) {
             return Optional.empty();
         }
 
@@ -58,6 +63,8 @@ public class KuFlowGroup {
         for (String pair : keyValuePairs) {
             int indexOfEquals = pair.indexOf("=");
             if (indexOfEquals == -1) {
+                LOGGER.debug("Invalid format in key-value pair '{}' on value '{}' ", pair, source);
+
                 return Optional.empty();
             }
 
@@ -69,11 +76,15 @@ public class KuFlowGroup {
             keyValueMap.put(key, value);
         }
 
-        UUID id = UUID.fromString(keyValueMap.remove(METADATA_ID));
-
+        UUID id = UUIDUtils.parseUuid(keyValueMap.remove(METADATA_ID));
         String type = keyValueMap.remove(METADATA_TYPE);
-
         String name = keyValueMap.remove(METADATA_NAME);
+
+        if (id == null || type == null) {
+            LOGGER.debug("Wrong format some parts are missing 'id={}' 'type={}'", id, type);
+
+            return Optional.empty();
+        }
 
         return Optional.of(new KuFlowGroup(source, id, type, name));
     }

--- a/kuflow-rest/src/main/java/com/kuflow/rest/util/UUIDUtils.java
+++ b/kuflow-rest/src/main/java/com/kuflow/rest/util/UUIDUtils.java
@@ -1,0 +1,40 @@
+/*
+ * The MIT License
+ * Copyright © 2021-present KuFlow S.L.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.kuflow.rest.util;
+
+import java.util.UUID;
+
+public class UUIDUtils {
+
+    public static UUID parseUuid(String value) {
+        if (value == null) {
+            return null;
+        }
+
+        try {
+            return UUID.fromString(value);
+        } catch (Exception ex) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Add KuFlowDataSource to parse and generate kuflow-data-source references with an optional name. Extract the duplicated UUID parsing logic into a shared UUIDUtils helper used across the metadata models.

Harden KuFlowGroup parsing against null/invalid ids and missing mandatory parts, and switch debug logging to slf4j parameterized messages instead of String.format.