### PR TITLE
feat: add entity field to business artifact action and process creation params

### DIFF
--- a/kuflow-rest/openapi/readme.md
+++ b/kuflow-rest/openapi/readme.md
@@ -27,7 +27,7 @@ java: true
 title: KuFlow
 override-client-name: KuFlowClient
 
-input-file: https://raw.githubusercontent.com/kuflow/kuflow-openapi/1542e1681535b248430589fefbd16abf349f334b/specs/api.kuflow.com/v2024-06-14/openapi.yaml
+input-file: https://raw.githubusercontent.com/kuflow/kuflow-openapi/15e1641a70549270dfaa4829a1ca7ada041ae500/specs/api.kuflow.com/v2024-06-14/openapi.yaml
 output-folder: ../target/openapi-generated
 
 openapi-type: data-plane

--- a/kuflow-rest/src/generated/java/com/kuflow/rest/model/BusinessArtifactActionCreateParamsStartProcess.java
+++ b/kuflow-rest/src/generated/java/com/kuflow/rest/model/BusinessArtifactActionCreateParamsStartProcess.java
@@ -45,6 +45,15 @@ public final class BusinessArtifactActionCreateParamsStartProcess
     @Generated
     private Map<String, Object> metadata;
 
+    /*
+     * Entity data applied to the process created by this action. Validated
+     * against the process definition entity schema; validation errors are
+     * recorded on the process entity value. Ignored if empty or if the
+     * process definition has no entity structure.
+     */
+    @Generated
+    private Map<String, Object> entity;
+
     /**
      * Creates an instance of BusinessArtifactActionCreateParamsStartProcess class.
      */
@@ -74,6 +83,34 @@ public final class BusinessArtifactActionCreateParamsStartProcess
     }
 
     /**
+     * Get the entity property: Entity data applied to the process created by this action. Validated
+     * against the process definition entity schema; validation errors are
+     * recorded on the process entity value. Ignored if empty or if the
+     * process definition has no entity structure.
+     *
+     * @return the entity value.
+     */
+    @Generated
+    public Map<String, Object> getEntity() {
+        return this.entity;
+    }
+
+    /**
+     * Set the entity property: Entity data applied to the process created by this action. Validated
+     * against the process definition entity schema; validation errors are
+     * recorded on the process entity value. Ignored if empty or if the
+     * process definition has no entity structure.
+     *
+     * @param entity the entity value to set.
+     * @return the BusinessArtifactActionCreateParamsStartProcess object itself.
+     */
+    @Generated
+    public BusinessArtifactActionCreateParamsStartProcess setEntity(Map<String, Object> entity) {
+        this.entity = entity;
+        return this;
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Generated
@@ -81,6 +118,7 @@ public final class BusinessArtifactActionCreateParamsStartProcess
     public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
         jsonWriter.writeStartObject();
         jsonWriter.writeMapField("metadata", this.metadata, (writer, element) -> writer.writeUntyped(element));
+        jsonWriter.writeMapField("entity", this.entity, (writer, element) -> writer.writeUntyped(element));
         return jsonWriter.writeEndObject();
     }
 
@@ -104,6 +142,9 @@ public final class BusinessArtifactActionCreateParamsStartProcess
                 if ("metadata".equals(fieldName)) {
                     Map<String, Object> metadata = reader.readMap(reader1 -> reader1.readUntyped());
                     deserializedBusinessArtifactActionCreateParamsStartProcess.metadata = metadata;
+                } else if ("entity".equals(fieldName)) {
+                    Map<String, Object> entity = reader.readMap(reader1 -> reader1.readUntyped());
+                    deserializedBusinessArtifactActionCreateParamsStartProcess.entity = entity;
                 } else {
                     reader.skipChildren();
                 }

--- a/kuflow-rest/src/generated/java/com/kuflow/rest/model/ProcessCreateParams.java
+++ b/kuflow-rest/src/generated/java/com/kuflow/rest/model/ProcessCreateParams.java
@@ -70,6 +70,12 @@ public final class ProcessCreateParams implements JsonSerializable<ProcessCreate
     private JsonValue metadata;
 
     /*
+     * Json value.
+     */
+    @Generated
+    private JsonValue entity;
+
+    /*
      * The initiatorId property.
      */
     @Generated
@@ -198,6 +204,28 @@ public final class ProcessCreateParams implements JsonSerializable<ProcessCreate
     }
 
     /**
+     * Get the entity property: Json value.
+     *
+     * @return the entity value.
+     */
+    @Generated
+    public JsonValue getEntity() {
+        return this.entity;
+    }
+
+    /**
+     * Set the entity property: Json value.
+     *
+     * @param entity the entity value to set.
+     * @return the ProcessCreateParams object itself.
+     */
+    @Generated
+    public ProcessCreateParams setEntity(JsonValue entity) {
+        this.entity = entity;
+        return this;
+    }
+
+    /**
      * Get the initiatorId property: The initiatorId property.
      *
      * @return the initiatorId value.
@@ -253,6 +281,7 @@ public final class ProcessCreateParams implements JsonSerializable<ProcessCreate
         jsonWriter.writeStringField("tenantId", Objects.toString(this.tenantId, null));
         jsonWriter.writeStringField("processDefinitionCode", this.processDefinitionCode);
         jsonWriter.writeJsonField("metadata", this.metadata);
+        jsonWriter.writeJsonField("entity", this.entity);
         jsonWriter.writeStringField("initiatorId", Objects.toString(this.initiatorId, null));
         jsonWriter.writeStringField("initiatorEmail", this.initiatorEmail);
         return jsonWriter.writeEndObject();
@@ -288,6 +317,8 @@ public final class ProcessCreateParams implements JsonSerializable<ProcessCreate
                     deserializedProcessCreateParams.processDefinitionCode = reader.getString();
                 } else if ("metadata".equals(fieldName)) {
                     deserializedProcessCreateParams.metadata = JsonValue.fromJson(reader);
+                } else if ("entity".equals(fieldName)) {
+                    deserializedProcessCreateParams.entity = JsonValue.fromJson(reader);
                 } else if ("initiatorId".equals(fieldName)) {
                     deserializedProcessCreateParams.initiatorId = reader.getNullable(nonNullReader ->
                         UUID.fromString(nonNullReader.getString())


### PR DESCRIPTION
## Summary

Add support for setting **entity** data when a process is created, both through the direct Process Create API and through the Business Artifact "create process" action.

## Changes

- `ProcessCreateParams`: add an `entity` field so initial entity data can be supplied at process creation time, instead of requiring a separate call afterwards to set it.
- `BusinessArtifactActionCreateParamsStartProcess`: add an `entity` field to the "start process" business artifact action params. This entity data is applied to the process created by the action, validated against the process definition's entity schema, with validation errors recorded on the resulting process entity value. It is ignored if empty or if the process definition has no entity structure.
- Bump the pinned KuFlow OpenAPI spec reference in `kuflow-rest/openapi/readme.md` to the version that introduces these `entity` fields, and regenerate the affected client models accordingly.

Closes #160