### PR TITLE
feat(rest): add relatedProcessId to ProcessCreateParams

### DIFF
--- a/kuflow-rest/openapi/readme.md
+++ b/kuflow-rest/openapi/readme.md
@@ -27,7 +27,7 @@ java: true
 title: KuFlow
 override-client-name: KuFlowClient
 
-input-file: https://raw.githubusercontent.com/kuflow/kuflow-openapi/15e1641a70549270dfaa4829a1ca7ada041ae500/specs/api.kuflow.com/v2024-06-14/openapi.yaml
+input-file: https://raw.githubusercontent.com/kuflow/kuflow-openapi/2f597a1edc7dbbed16013a30e89ec2066cce8aa1/specs/api.kuflow.com/v2024-06-14/openapi.yaml
 output-folder: ../target/openapi-generated
 
 openapi-type: data-plane

--- a/kuflow-rest/src/generated/java/com/kuflow/rest/model/ProcessCreateParams.java
+++ b/kuflow-rest/src/generated/java/com/kuflow/rest/model/ProcessCreateParams.java
@@ -87,6 +87,13 @@ public final class ProcessCreateParams implements JsonSerializable<ProcessCreate
     @Generated
     private String initiatorEmail;
 
+    /*
+     * Optional id of another process to which the created process is
+     * related. Surfaced on read as `Process.processRelated.outcoming`.
+     */
+    @Generated
+    private UUID relatedProcessId;
+
     /**
      * Creates an instance of ProcessCreateParams class.
      */
@@ -270,6 +277,30 @@ public final class ProcessCreateParams implements JsonSerializable<ProcessCreate
     }
 
     /**
+     * Get the relatedProcessId property: Optional id of another process to which the created process is
+     * related. Surfaced on read as `Process.processRelated.outcoming`.
+     *
+     * @return the relatedProcessId value.
+     */
+    @Generated
+    public UUID getRelatedProcessId() {
+        return this.relatedProcessId;
+    }
+
+    /**
+     * Set the relatedProcessId property: Optional id of another process to which the created process is
+     * related. Surfaced on read as `Process.processRelated.outcoming`.
+     *
+     * @param relatedProcessId the relatedProcessId value to set.
+     * @return the ProcessCreateParams object itself.
+     */
+    @Generated
+    public ProcessCreateParams setRelatedProcessId(UUID relatedProcessId) {
+        this.relatedProcessId = relatedProcessId;
+        return this;
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Generated
@@ -284,6 +315,7 @@ public final class ProcessCreateParams implements JsonSerializable<ProcessCreate
         jsonWriter.writeJsonField("entity", this.entity);
         jsonWriter.writeStringField("initiatorId", Objects.toString(this.initiatorId, null));
         jsonWriter.writeStringField("initiatorEmail", this.initiatorEmail);
+        jsonWriter.writeStringField("relatedProcessId", Objects.toString(this.relatedProcessId, null));
         return jsonWriter.writeEndObject();
     }
 
@@ -325,6 +357,10 @@ public final class ProcessCreateParams implements JsonSerializable<ProcessCreate
                     );
                 } else if ("initiatorEmail".equals(fieldName)) {
                     deserializedProcessCreateParams.initiatorEmail = reader.getString();
+                } else if ("relatedProcessId".equals(fieldName)) {
+                    deserializedProcessCreateParams.relatedProcessId = reader.getNullable(nonNullReader ->
+                        UUID.fromString(nonNullReader.getString())
+                    );
                 } else {
                     reader.skipChildren();
                 }


### PR DESCRIPTION
## Summary

Add support for creating a process linked to another related process, by exposing a new `relatedProcessId` field on the process create endpoint.

## Key changes

- Update the OpenAPI spec reference (`kuflow-rest/openapi/readme.md`) to the latest KuFlow API definition.
- Regenerate the REST client `ProcessCreateParams` to add the optional `relatedProcessId` field (getter, setter, JSON serialization/deserialization), surfaced on read as `Process.processRelated.outcoming`.

## Testing

- Generated via the standard OpenAPI codegen process; follows the same pattern as other existing fields on `ProcessCreateParams`.

Closes #162
