### PR TITLE
feat(rest): add metadata filter support to ProcessFindOptions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,75 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+This is the **KuFlow SDK for Java**: a multi-module Maven project (`com.kuflow:kuflow-sdk`) providing libraries for building Workers that integrate with the KuFlow platform. Integration is built on top of [Temporal](https://temporal.io) — KuFlow runs business processes as Temporal workflows, and these modules wrap the KuFlow REST API as Temporal activities plus the connection/worker plumbing to register them.
+
+Toolchain is pinned in `mise.toml` (Java 17 / Temurin, Maven 3.9.x, Node 24 + pnpm for the REST codegen). The POM targets `java.version=17` despite `CONTRIBUTING.md` still saying Java 11 — use 17.
+
+## Common Commands
+
+```bash
+./mvnw test                          # run all tests
+./mvnw install                       # full build + install to local repo
+./mvnw test -pl kuflow-rest          # build/test a single module
+./mvnw test -pl kuflow-rest -Dtest=ProcessOperationsTest          # single test class
+./mvnw test -pl kuflow-rest -Dtest=ProcessOperationsTest#myMethod # single test method
+```
+
+Use `-am` (`./mvnw test -pl <module> -am`) to also build the modules a target depends on.
+
+### Code style — runs in the `validate` phase of every build
+
+The build **fails** on style violations. Three gates run during `validate`: Checkstyle (`etc/checkstyle/`), prettier-java, and license headers. To auto-fix instead of just checking:
+
+```bash
+./mvnw prettier:write     # format Java sources
+./mvnw license:format     # apply/refresh MIT license headers
+```
+
+Every source file must carry the MIT header (`The MIT License / Copyright © 2021-present KuFlow S.L.`). New files without it will fail the build.
+
+## Module Architecture
+
+Modules are layered bottom-up; `kuflow-temporal-worker` and `kuflow-spring-boot-autoconfigure` sit at the top and pull the rest together.
+
+- **kuflow-common** — minimal shared annotations (e.g. `@Experimental`).
+- **kuflow-rest** — the KuFlow REST API client. See the generated-code note below; this is the most unusual module.
+- **kuflow-temporal-common** — shared Temporal pieces: `AbstractModel`, `CipherUtils`, `TemporalUtils`, exception types.
+- **kuflow-temporal-activity-\*** — Temporal activity implementations, one module per concern:
+  - `activity-kuflow` — the core: wraps `KuFlowRestClient` operations as Temporal activities (`KuFlowActivities` interface + `KuFlowActivitiesImpl`), with a request/response model class per operation under `model/`.
+  - `activity-email`, `activity-s3`, `activity-datasource`, `activity-robotframework`, `activity-uivision` — integration-specific activities.
+- **kuflow-temporal-workflow-kuflow** — workflow-side contracts: `KuFlowWorkflow` helpers, signal/user-action/business-artifact models, search-attribute enums. Code here is Temporal **workflow** code (deterministic constraints apply).
+- **kuflow-temporal-worker** — connection and worker lifecycle. `KuFlowTemporalConnection` is the fluent entry point (`instance(kuFlowRestClient)` → configure stubs/client/worker → build). Also houses:
+  - `jackson/` — custom serializers bridging Autorest-generated models into Temporal's payload serialization.
+  - `encryption/` — end-to-end payload encryption via a `PayloadCodec` + interceptors (`EncryptionPayloadConverter`, client/worker interceptors).
+  - `ssl/`, `authorization/`, `tracing/` (MDC context propagation).
+- **kuflow-spring-boot-autoconfigure** — Spring Boot starters. Auto-configurations are registered in `src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports` and bind `@ConfigurationProperties` from `properties/`. **When adding a new auto-configuration class, you must add it to that imports file** or Spring will not pick it up.
+
+The parent `pom.xml` `<dependencyManagement>` pins every internal module to `${project.version}` and centralizes third-party versions (Temporal SDK, AWS SDK, Jackson, Azure core). Add new dependency versions there, not in child POMs.
+
+## kuflow-rest: generated vs. hand-written code
+
+This module mixes **generated** and **hand-written** sources, and the distinction matters:
+
+- `src/generated/java/...` — produced by **Autorest** from the KuFlow OpenAPI spec. Contains `implementation/` (the low-level `KuFlowClientImpl` + per-tag `*OperationsImpl`) and ~100 model classes in `model/`. **Do not hand-edit these**; they are regenerated. The directory is added as an extra source root via `build-helper-maven-plugin` in `kuflow-rest/pom.xml`.
+- `src/main/java/...` — hand-written public API layered over the generated impl: `KuFlowRestClient` / `KuFlowRestClientBuilder` (the public entry point), the `operation/` wrappers (`ProcessOperations`, `ProcessItemOperations`, `BusinessArtifactOperations`, etc.) that delegate to the generated `*OperationsImpl`, hand-written `model/` extensions, and `util/`.
+
+### Regenerating the REST client
+
+The Autorest config and pinned OpenAPI spec commit live in `kuflow-rest/openapi/readme.md`. From `kuflow-rest/openapi/`:
+
+```bash
+pnpm install
+pnpm run generate     # autorest → copy into src/generated → prettier → license headers
+```
+
+To target a new API version, update the `input-file` spec URL and `API_VERSION` in `KuFlowRestClient`, regenerate, then reconcile the hand-written `operation/` wrappers and activity model classes against any signature changes.
+
+## Conventions
+
+- New activity operations follow the established pattern: a `model/XxxRequest` + `model/XxxResponse` pair, a method on the `KuFlowActivities` interface, an implementation in `KuFlowActivitiesImpl` delegating to `KuFlowRestClient`, and validation in `util/KuFlowActivitiesValidation`.
+- Commits use **conventional commits** format (see git history: `feat:`, etc.).
+- The released artifact is built from `.flattened-pom.xml` (flatten-maven-plugin, `ossrh` mode); publishing to Maven Central happens under the `release` profile (GPG signing + central-publishing). Don't edit flattened/backup POMs by hand.

--- a/kuflow-rest/openapi/readme.md
+++ b/kuflow-rest/openapi/readme.md
@@ -27,7 +27,7 @@ java: true
 title: KuFlow
 override-client-name: KuFlowClient
 
-input-file: https://raw.githubusercontent.com/kuflow/kuflow-openapi/2f597a1edc7dbbed16013a30e89ec2066cce8aa1/specs/api.kuflow.com/v2024-06-14/openapi.yaml
+input-file: https://raw.githubusercontent.com/kuflow/kuflow-openapi/652a5ab7639cec40266209fd6be4f083b4437e04/specs/api.kuflow.com/v2024-06-14/openapi.yaml
 output-folder: ../target/openapi-generated
 
 openapi-type: data-plane

--- a/kuflow-rest/src/generated/java/com/kuflow/rest/implementation/ProcessOperationsImpl.java
+++ b/kuflow-rest/src/generated/java/com/kuflow/rest/implementation/ProcessOperationsImpl.java
@@ -103,6 +103,7 @@ public final class ProcessOperationsImpl {
             @QueryParam(value = "tenantId", multipleQueryParams = true) List<String> tenantId,
             @QueryParam(value = "processDefinitionId", multipleQueryParams = true) List<String> processDefinitionId,
             @QueryParam(value = "processDefinitionCode", multipleQueryParams = true) List<String> processDefinitionCode,
+            @QueryParam(value = "metadata", multipleQueryParams = true) List<String> metadata,
             @HeaderParam("Accept") String accept,
             Context context
         );
@@ -118,6 +119,7 @@ public final class ProcessOperationsImpl {
             @QueryParam(value = "tenantId", multipleQueryParams = true) List<String> tenantId,
             @QueryParam(value = "processDefinitionId", multipleQueryParams = true) List<String> processDefinitionId,
             @QueryParam(value = "processDefinitionCode", multipleQueryParams = true) List<String> processDefinitionCode,
+            @QueryParam(value = "metadata", multipleQueryParams = true) List<String> metadata,
             @HeaderParam("Accept") String accept,
             Context context
         );
@@ -461,6 +463,12 @@ public final class ProcessOperationsImpl {
      * @param tenantId Filter by tenantId.
      * @param processDefinitionId Filter by process definition ids.
      * @param processDefinitionCode Filter by process definition codes.
+     * @param metadata Filter by process metadata field values. Each value is an expression with the format
+     * `fieldCode operation value1 value2...` (space-separated).
+     *
+     * Supported operations: `eq`, `le`, `ge`, `between`, `contains`, `in`.
+     *
+     * Filtering by metadata requires specifying exactly one `processDefinitionId` or `processDefinitionCode`.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws DefaultErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -473,10 +481,11 @@ public final class ProcessOperationsImpl {
         List<String> sort,
         List<UUID> tenantId,
         List<UUID> processDefinitionId,
-        List<String> processDefinitionCode
+        List<String> processDefinitionCode,
+        List<String> metadata
     ) {
         return FluxUtil.withContext(context ->
-            findProcessesWithResponseAsync(size, page, sort, tenantId, processDefinitionId, processDefinitionCode, context)
+            findProcessesWithResponseAsync(size, page, sort, tenantId, processDefinitionId, processDefinitionCode, metadata, context)
         );
     }
 
@@ -497,6 +506,12 @@ public final class ProcessOperationsImpl {
      * @param tenantId Filter by tenantId.
      * @param processDefinitionId Filter by process definition ids.
      * @param processDefinitionCode Filter by process definition codes.
+     * @param metadata Filter by process metadata field values. Each value is an expression with the format
+     * `fieldCode operation value1 value2...` (space-separated).
+     *
+     * Supported operations: `eq`, `le`, `ge`, `between`, `contains`, `in`.
+     *
+     * Filtering by metadata requires specifying exactly one `processDefinitionId` or `processDefinitionCode`.
      * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws DefaultErrorException thrown if the request is rejected by server.
@@ -511,6 +526,7 @@ public final class ProcessOperationsImpl {
         List<UUID> tenantId,
         List<UUID> processDefinitionId,
         List<String> processDefinitionCode,
+        List<String> metadata,
         Context context
     ) {
         final String accept = "application/json";
@@ -538,6 +554,12 @@ public final class ProcessOperationsImpl {
                   .stream()
                   .map(item -> Objects.toString(item, ""))
                   .collect(Collectors.toList());
+        List<String> metadataConverted = (metadata == null)
+            ? new ArrayList<>()
+            : metadata
+                  .stream()
+                  .map(item -> Objects.toString(item, ""))
+                  .collect(Collectors.toList());
         return service.findProcesses(
             this.client.getHost(),
             size,
@@ -546,6 +568,7 @@ public final class ProcessOperationsImpl {
             tenantIdConverted,
             processDefinitionIdConverted,
             processDefinitionCodeConverted,
+            metadataConverted,
             accept,
             context
         );
@@ -568,6 +591,12 @@ public final class ProcessOperationsImpl {
      * @param tenantId Filter by tenantId.
      * @param processDefinitionId Filter by process definition ids.
      * @param processDefinitionCode Filter by process definition codes.
+     * @param metadata Filter by process metadata field values. Each value is an expression with the format
+     * `fieldCode operation value1 value2...` (space-separated).
+     *
+     * Supported operations: `eq`, `le`, `ge`, `between`, `contains`, `in`.
+     *
+     * Filtering by metadata requires specifying exactly one `processDefinitionId` or `processDefinitionCode`.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws DefaultErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -580,10 +609,11 @@ public final class ProcessOperationsImpl {
         List<String> sort,
         List<UUID> tenantId,
         List<UUID> processDefinitionId,
-        List<String> processDefinitionCode
+        List<String> processDefinitionCode,
+        List<String> metadata
     ) {
-        return findProcessesWithResponseAsync(size, page, sort, tenantId, processDefinitionId, processDefinitionCode).flatMap(res ->
-            Mono.justOrEmpty(res.getValue())
+        return findProcessesWithResponseAsync(size, page, sort, tenantId, processDefinitionId, processDefinitionCode, metadata).flatMap(
+            res -> Mono.justOrEmpty(res.getValue())
         );
     }
 
@@ -606,45 +636,8 @@ public final class ProcessOperationsImpl {
         final List<UUID> tenantId = null;
         final List<UUID> processDefinitionId = null;
         final List<String> processDefinitionCode = null;
-        return findProcessesWithResponseAsync(size, page, sort, tenantId, processDefinitionId, processDefinitionCode).flatMap(res ->
-            Mono.justOrEmpty(res.getValue())
-        );
-    }
-
-    /**
-     * Find all accessible Processes
-     *
-     * List all the Processes that have been created and the credentials has access.
-     *
-     * Available sort query values: id, createdAt, lastModifiedAt.
-     *
-     * @param size The number of records returned within a single API call.
-     * @param page The page number of the current page in the returned records, 0 is the first page.
-     * @param sort Sorting criteria in the format: property{,asc|desc}. Example: createdAt,desc
-     *
-     * Default sort order is ascending. Multiple sort criteria are supported.
-     *
-     * Please refer to the method description for supported properties.
-     * @param tenantId Filter by tenantId.
-     * @param processDefinitionId Filter by process definition ids.
-     * @param processDefinitionCode Filter by process definition codes.
-     * @param context The context to associate with this operation.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws DefaultErrorException thrown if the request is rejected by server.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body on successful completion of {@link Mono}.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<ProcessPage> findProcessesAsync(
-        Integer size,
-        Integer page,
-        List<String> sort,
-        List<UUID> tenantId,
-        List<UUID> processDefinitionId,
-        List<String> processDefinitionCode,
-        Context context
-    ) {
-        return findProcessesWithResponseAsync(size, page, sort, tenantId, processDefinitionId, processDefinitionCode, context).flatMap(
+        final List<String> metadata = null;
+        return findProcessesWithResponseAsync(size, page, sort, tenantId, processDefinitionId, processDefinitionCode, metadata).flatMap(
             res -> Mono.justOrEmpty(res.getValue())
         );
     }
@@ -666,6 +659,64 @@ public final class ProcessOperationsImpl {
      * @param tenantId Filter by tenantId.
      * @param processDefinitionId Filter by process definition ids.
      * @param processDefinitionCode Filter by process definition codes.
+     * @param metadata Filter by process metadata field values. Each value is an expression with the format
+     * `fieldCode operation value1 value2...` (space-separated).
+     *
+     * Supported operations: `eq`, `le`, `ge`, `between`, `contains`, `in`.
+     *
+     * Filtering by metadata requires specifying exactly one `processDefinitionId` or `processDefinitionCode`.
+     * @param context The context to associate with this operation.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws DefaultErrorException thrown if the request is rejected by server.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<ProcessPage> findProcessesAsync(
+        Integer size,
+        Integer page,
+        List<String> sort,
+        List<UUID> tenantId,
+        List<UUID> processDefinitionId,
+        List<String> processDefinitionCode,
+        List<String> metadata,
+        Context context
+    ) {
+        return findProcessesWithResponseAsync(
+            size,
+            page,
+            sort,
+            tenantId,
+            processDefinitionId,
+            processDefinitionCode,
+            metadata,
+            context
+        ).flatMap(res -> Mono.justOrEmpty(res.getValue()));
+    }
+
+    /**
+     * Find all accessible Processes
+     *
+     * List all the Processes that have been created and the credentials has access.
+     *
+     * Available sort query values: id, createdAt, lastModifiedAt.
+     *
+     * @param size The number of records returned within a single API call.
+     * @param page The page number of the current page in the returned records, 0 is the first page.
+     * @param sort Sorting criteria in the format: property{,asc|desc}. Example: createdAt,desc
+     *
+     * Default sort order is ascending. Multiple sort criteria are supported.
+     *
+     * Please refer to the method description for supported properties.
+     * @param tenantId Filter by tenantId.
+     * @param processDefinitionId Filter by process definition ids.
+     * @param processDefinitionCode Filter by process definition codes.
+     * @param metadata Filter by process metadata field values. Each value is an expression with the format
+     * `fieldCode operation value1 value2...` (space-separated).
+     *
+     * Supported operations: `eq`, `le`, `ge`, `between`, `contains`, `in`.
+     *
+     * Filtering by metadata requires specifying exactly one `processDefinitionId` or `processDefinitionCode`.
      * @param context The context to associate with this operation.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws DefaultErrorException thrown if the request is rejected by server.
@@ -680,6 +731,7 @@ public final class ProcessOperationsImpl {
         List<UUID> tenantId,
         List<UUID> processDefinitionId,
         List<String> processDefinitionCode,
+        List<String> metadata,
         Context context
     ) {
         final String accept = "application/json";
@@ -707,6 +759,12 @@ public final class ProcessOperationsImpl {
                   .stream()
                   .map(item -> Objects.toString(item, ""))
                   .collect(Collectors.toList());
+        List<String> metadataConverted = (metadata == null)
+            ? new ArrayList<>()
+            : metadata
+                  .stream()
+                  .map(item -> Objects.toString(item, ""))
+                  .collect(Collectors.toList());
         return service.findProcessesSync(
             this.client.getHost(),
             size,
@@ -715,6 +773,7 @@ public final class ProcessOperationsImpl {
             tenantIdConverted,
             processDefinitionIdConverted,
             processDefinitionCodeConverted,
+            metadataConverted,
             accept,
             context
         );
@@ -737,6 +796,12 @@ public final class ProcessOperationsImpl {
      * @param tenantId Filter by tenantId.
      * @param processDefinitionId Filter by process definition ids.
      * @param processDefinitionCode Filter by process definition codes.
+     * @param metadata Filter by process metadata field values. Each value is an expression with the format
+     * `fieldCode operation value1 value2...` (space-separated).
+     *
+     * Supported operations: `eq`, `le`, `ge`, `between`, `contains`, `in`.
+     *
+     * Filtering by metadata requires specifying exactly one `processDefinitionId` or `processDefinitionCode`.
      * @throws IllegalArgumentException thrown if parameters fail the validation.
      * @throws DefaultErrorException thrown if the request is rejected by server.
      * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
@@ -749,9 +814,19 @@ public final class ProcessOperationsImpl {
         List<String> sort,
         List<UUID> tenantId,
         List<UUID> processDefinitionId,
-        List<String> processDefinitionCode
+        List<String> processDefinitionCode,
+        List<String> metadata
     ) {
-        return findProcessesWithResponse(size, page, sort, tenantId, processDefinitionId, processDefinitionCode, Context.NONE).getValue();
+        return findProcessesWithResponse(
+            size,
+            page,
+            sort,
+            tenantId,
+            processDefinitionId,
+            processDefinitionCode,
+            metadata,
+            Context.NONE
+        ).getValue();
     }
 
     /**
@@ -773,7 +848,17 @@ public final class ProcessOperationsImpl {
         final List<UUID> tenantId = null;
         final List<UUID> processDefinitionId = null;
         final List<String> processDefinitionCode = null;
-        return findProcessesWithResponse(size, page, sort, tenantId, processDefinitionId, processDefinitionCode, Context.NONE).getValue();
+        final List<String> metadata = null;
+        return findProcessesWithResponse(
+            size,
+            page,
+            sort,
+            tenantId,
+            processDefinitionId,
+            processDefinitionCode,
+            metadata,
+            Context.NONE
+        ).getValue();
     }
 
     /**

--- a/kuflow-rest/src/main/java/com/kuflow/rest/model/BusinessArtifactFindOptions.java
+++ b/kuflow-rest/src/main/java/com/kuflow/rest/model/BusinessArtifactFindOptions.java
@@ -22,8 +22,7 @@
  */
 package com.kuflow.rest.model;
 
-import static java.util.Collections.unmodifiableList;
-
+import com.kuflow.rest.util.SearchCriteriaUtils;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
@@ -89,7 +88,7 @@ public class BusinessArtifactFindOptions {
     }
 
     public List<String> getSorts() {
-        return unmodifiableList(this.sorts);
+        return List.copyOf(this.sorts);
     }
 
     public BusinessArtifactFindOptions setSorts(List<String> sorts) {
@@ -124,7 +123,7 @@ public class BusinessArtifactFindOptions {
     }
 
     public List<UUID> getTenantIds() {
-        return unmodifiableList(this.tenantIds);
+        return List.copyOf(this.tenantIds);
     }
 
     public BusinessArtifactFindOptions setTenantIds(List<UUID> tenantIds) {
@@ -159,7 +158,7 @@ public class BusinessArtifactFindOptions {
     }
 
     public List<UUID> getBusinessArtifactDefinitionIds() {
-        return unmodifiableList(this.businessArtifactDefinitionIds);
+        return List.copyOf(this.businessArtifactDefinitionIds);
     }
 
     public BusinessArtifactFindOptions setBusinessArtifactDefinitionIds(List<UUID> businessArtifactDefinitionIds) {
@@ -194,7 +193,7 @@ public class BusinessArtifactFindOptions {
     }
 
     public List<String> getBusinessArtifactDefinitionCodes() {
-        return unmodifiableList(this.businessArtifactDefinitionCodes);
+        return List.copyOf(this.businessArtifactDefinitionCodes);
     }
 
     public BusinessArtifactFindOptions setBusinessArtifactDefinitionCodes(List<String> businessArtifactDefinitionCodes) {
@@ -229,7 +228,7 @@ public class BusinessArtifactFindOptions {
     }
 
     public List<String> getValues() {
-        return unmodifiableList(this.values);
+        return List.copyOf(this.values);
     }
 
     public BusinessArtifactFindOptions setValues(List<String> values) {
@@ -247,6 +246,22 @@ public class BusinessArtifactFindOptions {
         return this.setValues(List.of(value));
     }
 
+    /**
+     * Sets a single "code operation value1 value2..." filter expression, built from its parts and safely
+     * encoded so that a value containing a space (or any character requiring percent-encoding) still
+     * round-trips correctly. See {@link com.kuflow.rest.util.SearchCriteriaUtils#encodeFilterExpression}
+     * for details on the encoding.
+     *
+     * @param code the field code to filter/sort by
+     * @param operation the operation code, e.g. "eq", "le", "ge", "between", "contains", "in"
+     * @param values one or more values for the operation
+     */
+    public BusinessArtifactFindOptions setValue(String code, String operation, String... values) {
+        String encoded = SearchCriteriaUtils.encodeFilterExpression(code, operation, values);
+
+        return this.setValue(encoded);
+    }
+
     public BusinessArtifactFindOptions addValue(String value) {
         Objects.requireNonNull(value, "'value' is required");
         if (!this.values.contains(value)) {
@@ -256,9 +271,31 @@ public class BusinessArtifactFindOptions {
         return this;
     }
 
+    /**
+     * Adds a single "code operation value1 value2..." filter expression, built from its parts and safely
+     * encoded so that a value containing a space (or any character requiring percent-encoding) still
+     * round-trips correctly. See {@link com.kuflow.rest.util.SearchCriteriaUtils#encodeFilterExpression}
+     * for details on the encoding.
+     *
+     * @param code the field code to filter/sort by
+     * @param operation the operation code, e.g. "eq", "le", "ge", "between", "contains", "in"
+     * @param values one or more values for the operation
+     */
+    public BusinessArtifactFindOptions addValue(String code, String operation, String... values) {
+        String encoded = SearchCriteriaUtils.encodeFilterExpression(code, operation, values);
+
+        return this.addValue(encoded);
+    }
+
     public BusinessArtifactFindOptions removeValue(String value) {
         Objects.requireNonNull(value, "'value' is required");
         this.values.remove(value);
+
+        return this;
+    }
+
+    public BusinessArtifactFindOptions removeValues() {
+        this.values.clear();
 
         return this;
     }

--- a/kuflow-rest/src/main/java/com/kuflow/rest/model/KuFlowBusinessArtifact.java
+++ b/kuflow-rest/src/main/java/com/kuflow/rest/model/KuFlowBusinessArtifact.java
@@ -172,6 +172,6 @@ public class KuFlowBusinessArtifact {
             return "";
         }
 
-        return URLEncoder.encode(value.trim(), StandardCharsets.UTF_8).replaceAll("\\+", "%20");
+        return URLEncoder.encode(value.trim(), StandardCharsets.UTF_8).replace("+", "%20");
     }
 }

--- a/kuflow-rest/src/main/java/com/kuflow/rest/model/KuFlowDataSource.java
+++ b/kuflow-rest/src/main/java/com/kuflow/rest/model/KuFlowDataSource.java
@@ -128,6 +128,6 @@ public class KuFlowDataSource {
     }
 
     private static String encode(String value) {
-        return URLEncoder.encode(value.trim(), StandardCharsets.UTF_8).replaceAll("\\+", "%20");
+        return URLEncoder.encode(value.trim(), StandardCharsets.UTF_8).replace("+", "%20");
     }
 }

--- a/kuflow-rest/src/main/java/com/kuflow/rest/model/KuFlowGroup.java
+++ b/kuflow-rest/src/main/java/com/kuflow/rest/model/KuFlowGroup.java
@@ -140,6 +140,6 @@ public class KuFlowGroup {
     }
 
     private static String encode(String value) {
-        return URLEncoder.encode(value.trim(), StandardCharsets.UTF_8).replaceAll("\\+", "%20");
+        return URLEncoder.encode(value.trim(), StandardCharsets.UTF_8).replace("+", "%20");
     }
 }

--- a/kuflow-rest/src/main/java/com/kuflow/rest/model/KuFlowPrincipal.java
+++ b/kuflow-rest/src/main/java/com/kuflow/rest/model/KuFlowPrincipal.java
@@ -179,6 +179,6 @@ public class KuFlowPrincipal {
             return "";
         }
 
-        return URLEncoder.encode(value.trim(), StandardCharsets.UTF_8).replaceAll("\\+", "%20");
+        return URLEncoder.encode(value.trim(), StandardCharsets.UTF_8).replace("+", "%20");
     }
 }

--- a/kuflow-rest/src/main/java/com/kuflow/rest/model/KuFlowProcess.java
+++ b/kuflow-rest/src/main/java/com/kuflow/rest/model/KuFlowProcess.java
@@ -161,6 +161,6 @@ public class KuFlowProcess {
             return "";
         }
 
-        return URLEncoder.encode(value.trim(), StandardCharsets.UTF_8).replaceAll("\\+", "%20");
+        return URLEncoder.encode(value.trim(), StandardCharsets.UTF_8).replace("+", "%20");
     }
 }

--- a/kuflow-rest/src/main/java/com/kuflow/rest/model/ProcessFindOptions.java
+++ b/kuflow-rest/src/main/java/com/kuflow/rest/model/ProcessFindOptions.java
@@ -22,8 +22,7 @@
  */
 package com.kuflow.rest.model;
 
-import static java.util.Collections.unmodifiableList;
-
+import com.kuflow.rest.util.SearchCriteriaUtils;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
@@ -63,6 +62,11 @@ public class ProcessFindOptions {
      */
     private final List<String> processDefinitionCodes = new LinkedList<>();
 
+    /**
+     * Filter by indexed metadata field values.
+     */
+    private final List<String> metadata = new LinkedList<>();
+
     public Integer getSize() {
         return this.size;
     }
@@ -84,7 +88,7 @@ public class ProcessFindOptions {
     }
 
     public List<String> getSorts() {
-        return unmodifiableList(this.sorts);
+        return List.copyOf(this.sorts);
     }
 
     public ProcessFindOptions setSorts(List<String> sorts) {
@@ -119,7 +123,7 @@ public class ProcessFindOptions {
     }
 
     public List<UUID> getTenantIds() {
-        return unmodifiableList(this.tenantIds);
+        return List.copyOf(this.tenantIds);
     }
 
     public ProcessFindOptions setTenantIds(List<UUID> tenantIds) {
@@ -154,7 +158,7 @@ public class ProcessFindOptions {
     }
 
     public List<UUID> getProcessDefinitionIds() {
-        return unmodifiableList(this.processDefinitionIds);
+        return List.copyOf(this.processDefinitionIds);
     }
 
     public ProcessFindOptions setProcessDefinitionIds(List<UUID> processDefinitionIds) {
@@ -189,7 +193,7 @@ public class ProcessFindOptions {
     }
 
     public List<String> getProcessDefinitionCodes() {
-        return unmodifiableList(this.processDefinitionCodes);
+        return List.copyOf(this.processDefinitionCodes);
     }
 
     public ProcessFindOptions setProcessDefinitionCodes(List<String> processDefinitionCodes) {
@@ -219,6 +223,79 @@ public class ProcessFindOptions {
     public ProcessFindOptions removeProcessDefinitionCode(String processDefinitionCode) {
         Objects.requireNonNull(processDefinitionCode, "'processDefinitionCode' is required");
         this.processDefinitionCodes.remove(processDefinitionCode);
+
+        return this;
+    }
+
+    public List<String> getMetadata() {
+        return List.copyOf(this.metadata);
+    }
+
+    public ProcessFindOptions setMetadata(List<String> metadata) {
+        this.metadata.clear();
+        if (metadata != null) {
+            this.metadata.addAll(metadata);
+        }
+
+        return this;
+    }
+
+    public ProcessFindOptions setMetadata(String metadata) {
+        Objects.requireNonNull(metadata, "'metadata' is required");
+
+        return this.setMetadata(List.of(metadata));
+    }
+
+    /**
+     * Sets a single "code operation value1 value2..." filter expression, built from its parts and safely
+     * encoded so that a value containing a space (or any character requiring percent-encoding) still
+     * round-trips correctly. See {@link com.kuflow.rest.util.SearchCriteriaUtils#encodeFilterExpression}
+     * for details on the encoding.
+     *
+     * @param code the metadata field code to filter/sort by
+     * @param operation the operation code, e.g. "eq", "le", "ge", "between", "contains", "in"
+     * @param values one or more values for the operation
+     */
+    public ProcessFindOptions setMetadata(String code, String operation, String... values) {
+        String encoded = SearchCriteriaUtils.encodeFilterExpression(code, operation, values);
+
+        return this.setMetadata(encoded);
+    }
+
+    public ProcessFindOptions addMetadata(String metadata) {
+        Objects.requireNonNull(metadata, "'metadata' is required");
+        if (!this.metadata.contains(metadata)) {
+            this.metadata.add(metadata);
+        }
+
+        return this;
+    }
+
+    /**
+     * Adds a single "code operation value1 value2..." filter expression, built from its parts and safely
+     * encoded so that a value containing a space (or any character requiring percent-encoding) still
+     * round-trips correctly. See {@link com.kuflow.rest.util.SearchCriteriaUtils#encodeFilterExpression}
+     * for details on the encoding.
+     *
+     * @param code the metadata field code to filter/sort by
+     * @param operation the operation code, e.g. "eq", "le", "ge", "between", "contains", "in"
+     * @param values one or more values for the operation
+     */
+    public ProcessFindOptions addMetadata(String code, String operation, String... values) {
+        String encoded = SearchCriteriaUtils.encodeFilterExpression(code, operation, values);
+
+        return this.addMetadata(encoded);
+    }
+
+    public ProcessFindOptions removeMetadata(String metadata) {
+        Objects.requireNonNull(metadata, "'metadata' is required");
+        this.metadata.remove(metadata);
+
+        return this;
+    }
+
+    public ProcessFindOptions removeMetadata() {
+        this.metadata.clear();
 
         return this;
     }

--- a/kuflow-rest/src/main/java/com/kuflow/rest/operation/ProcessOperations.java
+++ b/kuflow-rest/src/main/java/com/kuflow/rest/operation/ProcessOperations.java
@@ -84,8 +84,18 @@ public class ProcessOperations {
         List<UUID> tenantId = !options.getTenantIds().isEmpty() ? options.getTenantIds() : null;
         List<UUID> processDefinitionId = !options.getProcessDefinitionIds().isEmpty() ? options.getProcessDefinitionIds() : null;
         List<String> processDefinitionCode = !options.getProcessDefinitionCodes().isEmpty() ? options.getProcessDefinitionCodes() : null;
+        List<String> metadata = !options.getMetadata().isEmpty() ? options.getMetadata() : null;
 
-        return this.service.findProcessesWithResponse(size, page, sort, tenantId, processDefinitionId, processDefinitionCode, context);
+        return this.service.findProcessesWithResponse(
+            size,
+            page,
+            sort,
+            tenantId,
+            processDefinitionId,
+            processDefinitionCode,
+            metadata,
+            context
+        );
     }
 
     /**

--- a/kuflow-rest/src/main/java/com/kuflow/rest/util/SearchCriteriaUtils.java
+++ b/kuflow-rest/src/main/java/com/kuflow/rest/util/SearchCriteriaUtils.java
@@ -1,0 +1,80 @@
+/*
+ * The MIT License
+ * Copyright © 2021-present KuFlow S.L.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.kuflow.rest.util;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+/**
+ * Helpers for building "value"/"metadata" search-criteria filter expressions
+ * ({@code "code operation value1 value2..."}) used by the KuFlow REST API's search/sort query parameters
+ * (e.g. {@code BusinessArtifactFindOptions}, {@code ProcessFindOptions}).
+ */
+public final class SearchCriteriaUtils {
+
+    private SearchCriteriaUtils() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    /**
+     * Builds a "code operation value1 value2..." filter expression.
+     *
+     * <p>The server splits each expression on spaces, then decodes each resulting token (code, operation,
+     * each value) individually. So {@code code}, {@code operation} and each value are percent-encoded
+     * individually here (space becomes {@code %20}) before joining them with the literal space separator,
+     * so that a space or any other reserved character inside one of them doesn't collide with the
+     * separator. The HTTP client is responsible for percent-encoding the resulting expression as a whole
+     * when it places it on the wire as a query-parameter value; this method must not do that itself.
+     *
+     * @param code the field code to filter/sort by
+     * @param operation the operation code, e.g. "eq", "le", "ge", "between", "contains", "in"
+     * @param values one or more values for the operation
+     * @return the encoded filter expression, ready to be passed as a "value"/"metadata" query parameter
+     */
+    public static String encodeFilterExpression(String code, String operation, String... values) {
+        Objects.requireNonNull(code, "'code' is required");
+        Objects.requireNonNull(operation, "'operation' is required");
+        Objects.requireNonNull(values, "'values' is required");
+        if (values.length == 0) {
+            throw new IllegalArgumentException("At least one value is required");
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(encode(code));
+        sb.append(" ");
+        sb.append(encode(operation));
+
+        for (String value : values) {
+            Objects.requireNonNull(value, "'value' is required");
+            sb.append(" ");
+            sb.append(encode(value));
+        }
+
+        return sb.toString();
+    }
+
+    private static String encode(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20");
+    }
+}

--- a/kuflow-rest/src/test/java/com/kuflow/rest/operation/BusinessArtifactOperationTest.java
+++ b/kuflow-rest/src/test/java/com/kuflow/rest/operation/BusinessArtifactOperationTest.java
@@ -37,6 +37,7 @@ import com.kuflow.rest.model.BusinessArtifactFindOptions;
 import com.kuflow.rest.model.BusinessArtifactPage;
 import com.kuflow.rest.model.Document;
 import com.kuflow.rest.model.DocumentReference;
+import com.kuflow.rest.util.SearchCriteriaUtils;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -140,6 +141,22 @@ public class BusinessArtifactOperationTest extends AbstractOperationTest {
         assertThat(businessArtifacts.getContent()).hasSize(2);
         assertThat(businessArtifacts.getContent().get(0).getId()).isEqualTo(UUID.fromString("4f2467f1-00fa-4a6c-88ca-16ae8eac7b56"));
         assertThat(businessArtifacts.getContent().get(1).getId()).isEqualTo(UUID.fromString("2fd90b51-e1d8-44e3-89bd-8c4c9fc4164b"));
+    }
+
+    @Test
+    @DisplayName("GIVEN a value filter built from parts with a space WHEN list business artifacts THEN the encoded query parameter is sent")
+    public void givenValueFilterBuiltFromPartsWithASpaceWhenListBusinessArtifactsThenTheEncodedQueryParameterIsSent() {
+        String expectedValueParam = SearchCriteriaUtils.encodeFilterExpression("invoiceNumber", "eq", "INV 001");
+
+        givenThat(
+            get(urlPathEqualTo("/v2024-06-14/business-artifacts"))
+                .withQueryParam("value", equalTo(expectedValueParam))
+                .willReturn(ok().withHeader("Content-Type", "application/json").withBodyFile("business-artifacts-api.list.ok.json"))
+        );
+
+        BusinessArtifactFindOptions options = new BusinessArtifactFindOptions().addValue("invoiceNumber", "eq", "INV 001");
+
+        this.kuFlowRestClient.getBusinessArtifactOperations().findBusinessArtifacts(options);
     }
 
     @Test

--- a/kuflow-rest/src/test/java/com/kuflow/rest/operation/ProcessOperationTest.java
+++ b/kuflow-rest/src/test/java/com/kuflow/rest/operation/ProcessOperationTest.java
@@ -34,6 +34,7 @@ import com.kuflow.rest.model.ProcessFindOptions;
 import com.kuflow.rest.model.ProcessPage;
 import com.kuflow.rest.model.ProcessPageItem;
 import com.kuflow.rest.model.ProcessState;
+import com.kuflow.rest.util.SearchCriteriaUtils;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -114,6 +115,22 @@ public class ProcessOperationTest extends AbstractOperationTest {
             .addSort("order2")
             .addTenantId(tenantId1)
             .addTenantId(tenantId2);
+
+        this.kuFlowRestClient.getProcessOperations().findProcesses(options);
+    }
+
+    @Test
+    @DisplayName("GIVEN a metadata filter built from parts with a space WHEN list processes THEN the encoded query parameter is sent")
+    public void givenMetadataFilterBuiltFromPartsWithASpaceWhenListProcessesThenTheEncodedQueryParameterIsSent() {
+        String expectedMetadataParam = SearchCriteriaUtils.encodeFilterExpression("FIELD_STRING", "eq", "Text value");
+
+        givenThat(
+            get(urlPathEqualTo("/v2024-06-14/processes"))
+                .withQueryParam("metadata", equalTo(expectedMetadataParam))
+                .willReturn(ok().withHeader("Content-Type", "application/json").withBodyFile("processes-api.list.ok.json"))
+        );
+
+        ProcessFindOptions options = new ProcessFindOptions().addMetadata("FIELD_STRING", "eq", "Text value");
 
         this.kuFlowRestClient.getProcessOperations().findProcesses(options);
     }

--- a/kuflow-rest/src/test/java/com/kuflow/rest/util/SearchCriteriaUtilsTest.java
+++ b/kuflow-rest/src/test/java/com/kuflow/rest/util/SearchCriteriaUtilsTest.java
@@ -1,0 +1,137 @@
+/*
+ * The MIT License
+ * Copyright © 2021-present KuFlow S.L.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.kuflow.rest.util;
+
+import static com.kuflow.rest.util.SearchCriteriaUtils.encodeFilterExpression;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that {@link SearchCriteriaUtils#encodeFilterExpression} produces an expression that the KuFlow
+ * REST API server can parse back into the original code/operation/values.
+ *
+ * <p>The server's parser (kuflow-core's {@code SearchCriteriaParser}) is not on this module's classpath, so
+ * these tests replicate its exact decode sequence: split the expression on spaces, then decode each
+ * resulting token (code, operation, each value) individually. This is the same sequence used to design
+ * {@link SearchCriteriaUtils#encodeFilterExpression} in the first place.
+ */
+public class SearchCriteriaUtilsTest {
+
+    @Test
+    @DisplayName("GIVEN plain values WHEN encoded THEN the server-side parser recovers them unchanged")
+    public void givenPlainValuesWhenEncodedThenServerSideParserRecoversThemUnchanged() {
+        String expression = encodeFilterExpression("invoiceNumber", "eq", "INV-001");
+
+        ParsedCriterion parsed = parseSearchCriterion(expression);
+
+        assertThat(parsed.code()).isEqualTo("invoiceNumber");
+        assertThat(parsed.operation()).isEqualTo("eq");
+        assertThat(parsed.values()).containsExactly("INV-001");
+    }
+
+    @Test
+    @DisplayName("GIVEN a value with an embedded space WHEN encoded THEN the server-side parser recovers it intact")
+    public void givenValueWithEmbeddedSpaceWhenEncodedThenServerSideParserRecoversItIntact() {
+        String expression = encodeFilterExpression("FIELD_STRING", "eq", "Text value");
+
+        ParsedCriterion parsed = parseSearchCriterion(expression);
+
+        assertThat(parsed.code()).isEqualTo("FIELD_STRING");
+        assertThat(parsed.operation()).isEqualTo("eq");
+        assertThat(parsed.values()).containsExactly("Text value");
+    }
+
+    @Test
+    @DisplayName("GIVEN a value with a literal '+' WHEN encoded THEN the server-side parser recovers it intact")
+    public void givenValueWithLiteralPlusWhenEncodedThenServerSideParserRecoversItIntact() {
+        String expression = encodeFilterExpression("phone", "eq", "+1234567890");
+
+        ParsedCriterion parsed = parseSearchCriterion(expression);
+
+        assertThat(parsed.values()).containsExactly("+1234567890");
+    }
+
+    @Test
+    @DisplayName("GIVEN a value with a literal '%' WHEN encoded THEN the server-side parser recovers it intact")
+    public void givenValueWithLiteralPercentWhenEncodedThenServerSideParserRecoversItIntact() {
+        String expression = encodeFilterExpression("discount", "eq", "50%off");
+
+        ParsedCriterion parsed = parseSearchCriterion(expression);
+
+        assertThat(parsed.values()).containsExactly("50%off");
+    }
+
+    @Test
+    @DisplayName("GIVEN a multi-value operator WHEN encoded THEN the server-side parser recovers every value in order")
+    public void givenMultiValueOperatorWhenEncodedThenServerSideParserRecoversEveryValueInOrder() {
+        String expression = encodeFilterExpression("amount", "between", "10", "20");
+
+        ParsedCriterion parsed = parseSearchCriterion(expression);
+
+        assertThat(parsed.operation()).isEqualTo("between");
+        assertThat(parsed.values()).containsExactly("10", "20");
+    }
+
+    @Test
+    @DisplayName("GIVEN a multi-value operator with embedded spaces WHEN encoded THEN every value survives intact")
+    public void givenMultiValueOperatorWithEmbeddedSpacesWhenEncodedThenEveryValueSurvivesIntact() {
+        String expression = encodeFilterExpression("status", "in", "active now", "inactive later");
+
+        ParsedCriterion parsed = parseSearchCriterion(expression);
+
+        assertThat(parsed.operation()).isEqualTo("in");
+        assertThat(parsed.values()).containsExactly("active now", "inactive later");
+    }
+
+    @Test
+    @DisplayName("GIVEN no values WHEN building an expression THEN an exception is thrown")
+    public void givenNoValuesWhenBuildingAnExpressionThenAnExceptionIsThrown() {
+        assertThatThrownBy(() -> encodeFilterExpression("code", "eq")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private record ParsedCriterion(String code, String operation, List<String> values) {}
+
+    /**
+     * Mirrors kuflow-core's {@code SearchCriteriaParser.parseSearchCriterion} exactly: split on spaces,
+     * then decode each resulting token individually.
+     */
+    private static ParsedCriterion parseSearchCriterion(String filter) {
+        List<String> parts = List.of(filter.split(" "));
+
+        String code = URLDecoder.decode(parts.get(0), StandardCharsets.UTF_8);
+        String operation = URLDecoder.decode(parts.get(1), StandardCharsets.UTF_8);
+        List<String> values = parts
+            .subList(2, parts.size())
+            .stream()
+            .map(it -> URLDecoder.decode(it, StandardCharsets.UTF_8))
+            .toList();
+
+        return new ParsedCriterion(code, operation, values);
+    }
+}


### PR DESCRIPTION
## Summary

Adds convenience methods for building `metadata`/`value` search-criteria filter expressions from their
parts, so callers don't have to hand-format and encode the `code operation value1 value2...` string
themselves.

## Key changes

- New shared `SearchCriteriaUtils.encodeFilterExpression(code, operation, values...)`, which
  percent-encodes each part individually so a value containing a space or another reserved character
  round-trips correctly through the server's search-criteria parser.
- `ProcessFindOptions.setMetadata/addMetadata(code, operation, values...)` and the equivalent
  `BusinessArtifactFindOptions.setValue/addValue(code, operation, values...)`, built on top of that
  utility.
- Regenerates the REST client (`ProcessOperationsImpl`) against the `kuflow-openapi` commit that adds the
  `metadata` query parameter to `GET /processes`.
- Aligns a few existing `KuFlow*.java` URI encoders (`KuFlowProcess`, `KuFlowBusinessArtifact`,
  `KuFlowDataSource`, `KuFlowGroup`, `KuFlowPrincipal`) to the same `encode()` convention
  (`.replace("+", "%20")` instead of `.replaceAll("\\+", "%20")`).

## Testing

- New unit tests for `SearchCriteriaUtils` covering plain values, embedded spaces, literal `+`/`%`, and
  multi-value operators (`between`/`in`).
- New WireMock-based operation tests verifying the actual encoded query parameter sent over the wire for
  both `ProcessFindOptions` and `BusinessArtifactFindOptions`.

Closes #165
