### PR TITLE
feat(temporal): add tenantIds and metadata filters to ProcessFindRequest

### DIFF
--- a/kuflow-temporal-activity-kuflow/src/main/java/com/kuflow/temporal/activity/kuflow/KuFlowActivitiesImpl.java
+++ b/kuflow-temporal-activity-kuflow/src/main/java/com/kuflow/temporal/activity/kuflow/KuFlowActivitiesImpl.java
@@ -215,8 +215,10 @@ public class KuFlowActivitiesImpl implements KuFlowActivities {
                 .setPage(request.getPage())
                 .setSize(request.getSize())
                 .setSorts(request.getSorts())
+                .setTenantIds(request.getTenantIds())
                 .setProcessDefinitionIds(request.getProcessDefinitionIds())
-                .setProcessDefinitionCodes(request.getProcessDefinitionCodes());
+                .setProcessDefinitionCodes(request.getProcessDefinitionCodes())
+                .setMetadata(request.getMetadata());
 
             ProcessPage processes = this.processOperations.findProcesses(options);
 

--- a/kuflow-temporal-activity-kuflow/src/main/java/com/kuflow/temporal/activity/kuflow/model/BusinessArtifactFindRequest.java
+++ b/kuflow-temporal-activity-kuflow/src/main/java/com/kuflow/temporal/activity/kuflow/model/BusinessArtifactFindRequest.java
@@ -25,6 +25,7 @@ package com.kuflow.temporal.activity.kuflow.model;
 
 import static java.util.Collections.unmodifiableList;
 
+import com.kuflow.rest.util.SearchCriteriaUtils;
 import com.kuflow.temporal.common.model.AbstractModel;
 import java.util.LinkedList;
 import java.util.List;
@@ -249,6 +250,22 @@ public class BusinessArtifactFindRequest extends AbstractModel {
         return this.setValues(List.of(value));
     }
 
+    /**
+     * Sets a single "code operation value1 value2..." filter expression, built from its parts and safely
+     * encoded so that a value containing a space (or any character requiring percent-encoding) still
+     * round-trips correctly. See {@link SearchCriteriaUtils#encodeFilterExpression} for details on the
+     * encoding.
+     *
+     * @param code the field code to filter/sort by
+     * @param operation the operation code, e.g. "eq", "le", "ge", "between", "contains", "in"
+     * @param values one or more values for the operation
+     */
+    public BusinessArtifactFindRequest setValue(String code, String operation, String... values) {
+        String encoded = SearchCriteriaUtils.encodeFilterExpression(code, operation, values);
+
+        return this.setValue(encoded);
+    }
+
     public BusinessArtifactFindRequest addValue(String value) {
         Objects.requireNonNull(value, "'value' is required");
         if (!this.values.contains(value)) {
@@ -256,6 +273,22 @@ public class BusinessArtifactFindRequest extends AbstractModel {
         }
 
         return this;
+    }
+
+    /**
+     * Adds a single "code operation value1 value2..." filter expression, built from its parts and safely
+     * encoded so that a value containing a space (or any character requiring percent-encoding) still
+     * round-trips correctly. See {@link SearchCriteriaUtils#encodeFilterExpression} for details on the
+     * encoding.
+     *
+     * @param code the field code to filter/sort by
+     * @param operation the operation code, e.g. "eq", "le", "ge", "between", "contains", "in"
+     * @param values one or more values for the operation
+     */
+    public BusinessArtifactFindRequest addValue(String code, String operation, String... values) {
+        String encoded = SearchCriteriaUtils.encodeFilterExpression(code, operation, values);
+
+        return this.addValue(encoded);
     }
 
     public BusinessArtifactFindRequest removeValue(String value) {

--- a/kuflow-temporal-activity-kuflow/src/main/java/com/kuflow/temporal/activity/kuflow/model/ProcessFindRequest.java
+++ b/kuflow-temporal-activity-kuflow/src/main/java/com/kuflow/temporal/activity/kuflow/model/ProcessFindRequest.java
@@ -25,6 +25,7 @@ package com.kuflow.temporal.activity.kuflow.model;
 
 import static java.util.Collections.unmodifiableList;
 
+import com.kuflow.rest.util.SearchCriteriaUtils;
 import com.kuflow.temporal.common.model.AbstractModel;
 import java.util.LinkedList;
 import java.util.List;
@@ -40,6 +41,11 @@ public class ProcessFindRequest extends AbstractModel {
     private List<String> sorts;
 
     /**
+     * Filter by tenantId.
+     */
+    private final List<UUID> tenantIds = new LinkedList<>();
+
+    /**
      * Filter by process definition ids.
      */
     private final List<UUID> processDefinitionIds = new LinkedList<>();
@@ -48,6 +54,11 @@ public class ProcessFindRequest extends AbstractModel {
      * Filter by process definition codes.
      */
     private final List<String> processDefinitionCodes = new LinkedList<>();
+
+    /**
+     * Filter by indexed metadata field values.
+     */
+    private final List<String> metadata = new LinkedList<>();
 
     public Integer getPage() {
         return this.page;
@@ -90,6 +101,41 @@ public class ProcessFindRequest extends AbstractModel {
     public void removeSort(String sort) {
         Objects.requireNonNull(sort, "'sort' is required");
         this.sorts.remove(sort);
+    }
+
+    public List<UUID> getTenantIds() {
+        return unmodifiableList(this.tenantIds);
+    }
+
+    public ProcessFindRequest setTenantIds(List<UUID> tenantIds) {
+        this.tenantIds.clear();
+        if (tenantIds != null) {
+            this.tenantIds.addAll(tenantIds);
+        }
+
+        return this;
+    }
+
+    public ProcessFindRequest setTenantId(UUID tenantId) {
+        Objects.requireNonNull(tenantId, "'tenantId' is required");
+
+        return this.setTenantIds(List.of(tenantId));
+    }
+
+    public ProcessFindRequest addTenantId(UUID tenantId) {
+        Objects.requireNonNull(tenantId, "'tenantId' is required");
+        if (!this.tenantIds.contains(tenantId)) {
+            this.tenantIds.add(tenantId);
+        }
+
+        return this;
+    }
+
+    public ProcessFindRequest removeTenantId(UUID tenantId) {
+        Objects.requireNonNull(tenantId, "'tenantId' is required");
+        this.tenantIds.remove(tenantId);
+
+        return this;
     }
 
     public List<UUID> getProcessDefinitionIds() {
@@ -158,6 +204,73 @@ public class ProcessFindRequest extends AbstractModel {
     public ProcessFindRequest removeProcessDefinitionCode(String processDefinitionCode) {
         Objects.requireNonNull(processDefinitionCode, "'processDefinitionCode' is required");
         this.processDefinitionCodes.remove(processDefinitionCode);
+
+        return this;
+    }
+
+    public List<String> getMetadata() {
+        return unmodifiableList(this.metadata);
+    }
+
+    public ProcessFindRequest setMetadata(List<String> metadata) {
+        this.metadata.clear();
+        if (metadata != null) {
+            this.metadata.addAll(metadata);
+        }
+
+        return this;
+    }
+
+    public ProcessFindRequest setMetadata(String metadata) {
+        Objects.requireNonNull(metadata, "'metadata' is required");
+
+        return this.setMetadata(List.of(metadata));
+    }
+
+    /**
+     * Sets a single "code operation value1 value2..." filter expression, built from its parts and safely
+     * encoded so that a value containing a space (or any character requiring percent-encoding) still
+     * round-trips correctly. See {@link SearchCriteriaUtils#encodeFilterExpression} for details on the
+     * encoding.
+     *
+     * @param code the metadata field code to filter/sort by
+     * @param operation the operation code, e.g. "eq", "le", "ge", "between", "contains", "in"
+     * @param values one or more values for the operation
+     */
+    public ProcessFindRequest setMetadata(String code, String operation, String... values) {
+        String encoded = SearchCriteriaUtils.encodeFilterExpression(code, operation, values);
+
+        return this.setMetadata(encoded);
+    }
+
+    public ProcessFindRequest addMetadata(String metadata) {
+        Objects.requireNonNull(metadata, "'metadata' is required");
+        if (!this.metadata.contains(metadata)) {
+            this.metadata.add(metadata);
+        }
+
+        return this;
+    }
+
+    /**
+     * Adds a single "code operation value1 value2..." filter expression, built from its parts and safely
+     * encoded so that a value containing a space (or any character requiring percent-encoding) still
+     * round-trips correctly. See {@link SearchCriteriaUtils#encodeFilterExpression} for details on the
+     * encoding.
+     *
+     * @param code the metadata field code to filter/sort by
+     * @param operation the operation code, e.g. "eq", "le", "ge", "between", "contains", "in"
+     * @param values one or more values for the operation
+     */
+    public ProcessFindRequest addMetadata(String code, String operation, String... values) {
+        String encoded = SearchCriteriaUtils.encodeFilterExpression(code, operation, values);
+
+        return this.addMetadata(encoded);
+    }
+
+    public ProcessFindRequest removeMetadata(String metadata) {
+        Objects.requireNonNull(metadata, "'metadata' is required");
+        this.metadata.remove(metadata);
 
         return this;
     }


### PR DESCRIPTION
## Summary

`kuflow-rest`'s `ProcessFindOptions` and `BusinessArtifactFindOptions` recently gained new/underused query-parameter filters, but the Temporal-facing activity request models hadn't caught up, so workflows had no way to use them.

## Key changes

- `ProcessFindRequest` now exposes `tenantIds` and `metadata` filters (getters/setters/add/remove, plus `setMetadata(code, operation, values...)` / `addMetadata(code, operation, values...)` convenience builders), mirroring `ProcessFindOptions`.
- `KuFlowActivitiesImpl.findProcesses` maps `tenantIds` and `metadata` through to the REST `ProcessFindOptions` call.
- `BusinessArtifactFindRequest` gains the `setValue(code, operation, values...)` / `addValue(code, operation, values...)` convenience builders, mirroring `BusinessArtifactFindOptions` (its filter fields were already complete).

## Testing

`./mvnw test -pl kuflow-temporal-activity-kuflow -am` — build succeeds, Checkstyle/Spotless validation passes, all existing tests green.

Closes #167
