### PR TITLE
feat: add state and initiator filters to process find

### DIFF
--- a/kuflow-rest/openapi/readme.md
+++ b/kuflow-rest/openapi/readme.md
@@ -27,7 +27,7 @@ java: true
 title: KuFlow
 override-client-name: KuFlowClient
 
-input-file: https://raw.githubusercontent.com/kuflow/kuflow-openapi/652a5ab7639cec40266209fd6be4f083b4437e04/specs/api.kuflow.com/v2024-06-14/openapi.yaml
+input-file: https://raw.githubusercontent.com/kuflow/kuflow-openapi/c1299210be90059311601adf9260de556ecdfe6e/specs/api.kuflow.com/v2024-06-14/openapi.yaml
 output-folder: ../target/openapi-generated
 
 openapi-type: data-plane

--- a/kuflow-rest/src/generated/java/com/kuflow/rest/implementation/ProcessOperationsImpl.java
+++ b/kuflow-rest/src/generated/java/com/kuflow/rest/implementation/ProcessOperationsImpl.java
@@ -52,6 +52,7 @@ import com.kuflow.rest.model.ProcessCreateParams;
 import com.kuflow.rest.model.ProcessEntityUpdateParams;
 import com.kuflow.rest.model.ProcessMetadataUpdateParams;
 import com.kuflow.rest.model.ProcessPage;
+import com.kuflow.rest.model.ProcessState;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
@@ -104,6 +105,9 @@ public final class ProcessOperationsImpl {
             @QueryParam(value = "tenantId", multipleQueryParams = true) List<String> tenantId,
             @QueryParam(value = "processDefinitionId", multipleQueryParams = true) List<String> processDefinitionId,
             @QueryParam(value = "processDefinitionCode", multipleQueryParams = true) List<String> processDefinitionCode,
+            @QueryParam(value = "state", multipleQueryParams = true) List<String> state,
+            @QueryParam(value = "initiatorId", multipleQueryParams = true) List<String> initiatorId,
+            @QueryParam(value = "initiatorEmail", multipleQueryParams = true) List<String> initiatorEmail,
             @QueryParam(value = "metadata", multipleQueryParams = true) List<String> metadata,
             @HeaderParam("Accept") String accept,
             Context context
@@ -120,6 +124,9 @@ public final class ProcessOperationsImpl {
             @QueryParam(value = "tenantId", multipleQueryParams = true) List<String> tenantId,
             @QueryParam(value = "processDefinitionId", multipleQueryParams = true) List<String> processDefinitionId,
             @QueryParam(value = "processDefinitionCode", multipleQueryParams = true) List<String> processDefinitionCode,
+            @QueryParam(value = "state", multipleQueryParams = true) List<String> state,
+            @QueryParam(value = "initiatorId", multipleQueryParams = true) List<String> initiatorId,
+            @QueryParam(value = "initiatorEmail", multipleQueryParams = true) List<String> initiatorEmail,
             @QueryParam(value = "metadata", multipleQueryParams = true) List<String> metadata,
             @HeaderParam("Accept") String accept,
             Context context
@@ -464,6 +471,9 @@ public final class ProcessOperationsImpl {
      * @param tenantId Filter by tenantId.
      * @param processDefinitionId Filter by process definition ids.
      * @param processDefinitionCode Filter by process definition codes.
+     * @param state Filter by an array of process states.
+     * @param initiatorId Filter by an array of initiator ids, Principal ID.
+     * @param initiatorEmail Filter by an array of initiator emails.
      * @param metadata Filter by process metadata field values. Each value is an expression with the format
      * `fieldCode operation value1 value2...` (space-separated).
      *
@@ -483,10 +493,25 @@ public final class ProcessOperationsImpl {
         List<UUID> tenantId,
         List<UUID> processDefinitionId,
         List<String> processDefinitionCode,
+        List<ProcessState> state,
+        List<UUID> initiatorId,
+        List<String> initiatorEmail,
         List<String> metadata
     ) {
         return FluxUtil.withContext(context ->
-            findProcessesWithResponseAsync(size, page, sort, tenantId, processDefinitionId, processDefinitionCode, metadata, context)
+            findProcessesWithResponseAsync(
+                size,
+                page,
+                sort,
+                tenantId,
+                processDefinitionId,
+                processDefinitionCode,
+                state,
+                initiatorId,
+                initiatorEmail,
+                metadata,
+                context
+            )
         );
     }
 
@@ -507,6 +532,9 @@ public final class ProcessOperationsImpl {
      * @param tenantId Filter by tenantId.
      * @param processDefinitionId Filter by process definition ids.
      * @param processDefinitionCode Filter by process definition codes.
+     * @param state Filter by an array of process states.
+     * @param initiatorId Filter by an array of initiator ids, Principal ID.
+     * @param initiatorEmail Filter by an array of initiator emails.
      * @param metadata Filter by process metadata field values. Each value is an expression with the format
      * `fieldCode operation value1 value2...` (space-separated).
      *
@@ -527,6 +555,9 @@ public final class ProcessOperationsImpl {
         List<UUID> tenantId,
         List<UUID> processDefinitionId,
         List<String> processDefinitionCode,
+        List<ProcessState> state,
+        List<UUID> initiatorId,
+        List<String> initiatorEmail,
         List<String> metadata,
         Context context
     ) {
@@ -559,6 +590,27 @@ public final class ProcessOperationsImpl {
                       .stream()
                       .map(item -> Objects.toString(item, ""))
                       .collect(Collectors.toList());
+        List<String> stateConverted =
+            state == null
+                ? new ArrayList<>()
+                : state
+                      .stream()
+                      .map(item -> Objects.toString(item, ""))
+                      .collect(Collectors.toList());
+        List<String> initiatorIdConverted =
+            initiatorId == null
+                ? new ArrayList<>()
+                : initiatorId
+                      .stream()
+                      .map(item -> Objects.toString(item, ""))
+                      .collect(Collectors.toList());
+        List<String> initiatorEmailConverted =
+            initiatorEmail == null
+                ? new ArrayList<>()
+                : initiatorEmail
+                      .stream()
+                      .map(item -> Objects.toString(item, ""))
+                      .collect(Collectors.toList());
         List<String> metadataConverted =
             metadata == null
                 ? new ArrayList<>()
@@ -574,6 +626,9 @@ public final class ProcessOperationsImpl {
             tenantIdConverted,
             processDefinitionIdConverted,
             processDefinitionCodeConverted,
+            stateConverted,
+            initiatorIdConverted,
+            initiatorEmailConverted,
             metadataConverted,
             accept,
             context
@@ -597,6 +652,9 @@ public final class ProcessOperationsImpl {
      * @param tenantId Filter by tenantId.
      * @param processDefinitionId Filter by process definition ids.
      * @param processDefinitionCode Filter by process definition codes.
+     * @param state Filter by an array of process states.
+     * @param initiatorId Filter by an array of initiator ids, Principal ID.
+     * @param initiatorEmail Filter by an array of initiator emails.
      * @param metadata Filter by process metadata field values. Each value is an expression with the format
      * `fieldCode operation value1 value2...` (space-separated).
      *
@@ -616,11 +674,23 @@ public final class ProcessOperationsImpl {
         List<UUID> tenantId,
         List<UUID> processDefinitionId,
         List<String> processDefinitionCode,
+        List<ProcessState> state,
+        List<UUID> initiatorId,
+        List<String> initiatorEmail,
         List<String> metadata
     ) {
-        return findProcessesWithResponseAsync(size, page, sort, tenantId, processDefinitionId, processDefinitionCode, metadata).flatMap(
-            res -> Mono.justOrEmpty(res.getValue())
-        );
+        return findProcessesWithResponseAsync(
+            size,
+            page,
+            sort,
+            tenantId,
+            processDefinitionId,
+            processDefinitionCode,
+            state,
+            initiatorId,
+            initiatorEmail,
+            metadata
+        ).flatMap(res -> Mono.justOrEmpty(res.getValue()));
     }
 
     /**
@@ -642,10 +712,22 @@ public final class ProcessOperationsImpl {
         final List<UUID> tenantId = null;
         final List<UUID> processDefinitionId = null;
         final List<String> processDefinitionCode = null;
+        final List<ProcessState> state = null;
+        final List<UUID> initiatorId = null;
+        final List<String> initiatorEmail = null;
         final List<String> metadata = null;
-        return findProcessesWithResponseAsync(size, page, sort, tenantId, processDefinitionId, processDefinitionCode, metadata).flatMap(
-            res -> Mono.justOrEmpty(res.getValue())
-        );
+        return findProcessesWithResponseAsync(
+            size,
+            page,
+            sort,
+            tenantId,
+            processDefinitionId,
+            processDefinitionCode,
+            state,
+            initiatorId,
+            initiatorEmail,
+            metadata
+        ).flatMap(res -> Mono.justOrEmpty(res.getValue()));
     }
 
     /**
@@ -665,6 +747,9 @@ public final class ProcessOperationsImpl {
      * @param tenantId Filter by tenantId.
      * @param processDefinitionId Filter by process definition ids.
      * @param processDefinitionCode Filter by process definition codes.
+     * @param state Filter by an array of process states.
+     * @param initiatorId Filter by an array of initiator ids, Principal ID.
+     * @param initiatorEmail Filter by an array of initiator emails.
      * @param metadata Filter by process metadata field values. Each value is an expression with the format
      * `fieldCode operation value1 value2...` (space-separated).
      *
@@ -685,6 +770,9 @@ public final class ProcessOperationsImpl {
         List<UUID> tenantId,
         List<UUID> processDefinitionId,
         List<String> processDefinitionCode,
+        List<ProcessState> state,
+        List<UUID> initiatorId,
+        List<String> initiatorEmail,
         List<String> metadata,
         Context context
     ) {
@@ -695,6 +783,9 @@ public final class ProcessOperationsImpl {
             tenantId,
             processDefinitionId,
             processDefinitionCode,
+            state,
+            initiatorId,
+            initiatorEmail,
             metadata,
             context
         ).flatMap(res -> Mono.justOrEmpty(res.getValue()));
@@ -717,6 +808,9 @@ public final class ProcessOperationsImpl {
      * @param tenantId Filter by tenantId.
      * @param processDefinitionId Filter by process definition ids.
      * @param processDefinitionCode Filter by process definition codes.
+     * @param state Filter by an array of process states.
+     * @param initiatorId Filter by an array of initiator ids, Principal ID.
+     * @param initiatorEmail Filter by an array of initiator emails.
      * @param metadata Filter by process metadata field values. Each value is an expression with the format
      * `fieldCode operation value1 value2...` (space-separated).
      *
@@ -737,6 +831,9 @@ public final class ProcessOperationsImpl {
         List<UUID> tenantId,
         List<UUID> processDefinitionId,
         List<String> processDefinitionCode,
+        List<ProcessState> state,
+        List<UUID> initiatorId,
+        List<String> initiatorEmail,
         List<String> metadata,
         Context context
     ) {
@@ -769,6 +866,27 @@ public final class ProcessOperationsImpl {
                       .stream()
                       .map(item -> Objects.toString(item, ""))
                       .collect(Collectors.toList());
+        List<String> stateConverted =
+            state == null
+                ? new ArrayList<>()
+                : state
+                      .stream()
+                      .map(item -> Objects.toString(item, ""))
+                      .collect(Collectors.toList());
+        List<String> initiatorIdConverted =
+            initiatorId == null
+                ? new ArrayList<>()
+                : initiatorId
+                      .stream()
+                      .map(item -> Objects.toString(item, ""))
+                      .collect(Collectors.toList());
+        List<String> initiatorEmailConverted =
+            initiatorEmail == null
+                ? new ArrayList<>()
+                : initiatorEmail
+                      .stream()
+                      .map(item -> Objects.toString(item, ""))
+                      .collect(Collectors.toList());
         List<String> metadataConverted =
             metadata == null
                 ? new ArrayList<>()
@@ -784,6 +902,9 @@ public final class ProcessOperationsImpl {
             tenantIdConverted,
             processDefinitionIdConverted,
             processDefinitionCodeConverted,
+            stateConverted,
+            initiatorIdConverted,
+            initiatorEmailConverted,
             metadataConverted,
             accept,
             context
@@ -807,6 +928,9 @@ public final class ProcessOperationsImpl {
      * @param tenantId Filter by tenantId.
      * @param processDefinitionId Filter by process definition ids.
      * @param processDefinitionCode Filter by process definition codes.
+     * @param state Filter by an array of process states.
+     * @param initiatorId Filter by an array of initiator ids, Principal ID.
+     * @param initiatorEmail Filter by an array of initiator emails.
      * @param metadata Filter by process metadata field values. Each value is an expression with the format
      * `fieldCode operation value1 value2...` (space-separated).
      *
@@ -826,6 +950,9 @@ public final class ProcessOperationsImpl {
         List<UUID> tenantId,
         List<UUID> processDefinitionId,
         List<String> processDefinitionCode,
+        List<ProcessState> state,
+        List<UUID> initiatorId,
+        List<String> initiatorEmail,
         List<String> metadata
     ) {
         return findProcessesWithResponse(
@@ -835,6 +962,9 @@ public final class ProcessOperationsImpl {
             tenantId,
             processDefinitionId,
             processDefinitionCode,
+            state,
+            initiatorId,
+            initiatorEmail,
             metadata,
             Context.NONE
         ).getValue();
@@ -859,6 +989,9 @@ public final class ProcessOperationsImpl {
         final List<UUID> tenantId = null;
         final List<UUID> processDefinitionId = null;
         final List<String> processDefinitionCode = null;
+        final List<ProcessState> state = null;
+        final List<UUID> initiatorId = null;
+        final List<String> initiatorEmail = null;
         final List<String> metadata = null;
         return findProcessesWithResponse(
             size,
@@ -867,6 +1000,9 @@ public final class ProcessOperationsImpl {
             tenantId,
             processDefinitionId,
             processDefinitionCode,
+            state,
+            initiatorId,
+            initiatorEmail,
             metadata,
             Context.NONE
         ).getValue();

--- a/kuflow-rest/src/main/java/com/kuflow/rest/model/ProcessFindOptions.java
+++ b/kuflow-rest/src/main/java/com/kuflow/rest/model/ProcessFindOptions.java
@@ -64,6 +64,21 @@ public class ProcessFindOptions {
     private final List<String> processDefinitionCodes = new LinkedList<>();
 
     /**
+     * Filter by an array of process states.
+     */
+    private final List<ProcessState> states = new LinkedList<>();
+
+    /**
+     * Filter by an array of initiator ids.
+     */
+    private final List<UUID> initiatorIds = new LinkedList<>();
+
+    /**
+     * Filter by an array of initiator emails.
+     */
+    private final List<String> initiatorEmails = new LinkedList<>();
+
+    /**
      * Filter by indexed metadata field values.
      */
     private final List<String> metadata = new LinkedList<>();
@@ -224,6 +239,111 @@ public class ProcessFindOptions {
     public ProcessFindOptions removeProcessDefinitionCode(String processDefinitionCode) {
         Objects.requireNonNull(processDefinitionCode, "'processDefinitionCode' is required");
         this.processDefinitionCodes.remove(processDefinitionCode);
+
+        return this;
+    }
+
+    public List<ProcessState> getStates() {
+        return List.copyOf(this.states);
+    }
+
+    public ProcessFindOptions setStates(List<ProcessState> states) {
+        this.states.clear();
+        if (states != null) {
+            this.states.addAll(states);
+        }
+
+        return this;
+    }
+
+    public ProcessFindOptions setState(ProcessState state) {
+        Objects.requireNonNull(state, "'state' is required");
+
+        return this.setStates(List.of(state));
+    }
+
+    public ProcessFindOptions addState(ProcessState state) {
+        Objects.requireNonNull(state, "'state' is required");
+        if (!this.states.contains(state)) {
+            this.states.add(state);
+        }
+
+        return this;
+    }
+
+    public ProcessFindOptions removeState(ProcessState state) {
+        Objects.requireNonNull(state, "'state' is required");
+        this.states.remove(state);
+
+        return this;
+    }
+
+    public List<UUID> getInitiatorIds() {
+        return List.copyOf(this.initiatorIds);
+    }
+
+    public ProcessFindOptions setInitiatorIds(List<UUID> initiatorIds) {
+        this.initiatorIds.clear();
+        if (initiatorIds != null) {
+            this.initiatorIds.addAll(initiatorIds);
+        }
+
+        return this;
+    }
+
+    public ProcessFindOptions setInitiatorId(UUID initiatorId) {
+        Objects.requireNonNull(initiatorId, "'initiatorId' is required");
+
+        return this.setInitiatorIds(List.of(initiatorId));
+    }
+
+    public ProcessFindOptions addInitiatorId(UUID initiatorId) {
+        Objects.requireNonNull(initiatorId, "'initiatorId' is required");
+        if (!this.initiatorIds.contains(initiatorId)) {
+            this.initiatorIds.add(initiatorId);
+        }
+
+        return this;
+    }
+
+    public ProcessFindOptions removeInitiatorId(UUID initiatorId) {
+        Objects.requireNonNull(initiatorId, "'initiatorId' is required");
+        this.initiatorIds.remove(initiatorId);
+
+        return this;
+    }
+
+    public List<String> getInitiatorEmails() {
+        return List.copyOf(this.initiatorEmails);
+    }
+
+    public ProcessFindOptions setInitiatorEmails(List<String> initiatorEmails) {
+        this.initiatorEmails.clear();
+        if (initiatorEmails != null) {
+            this.initiatorEmails.addAll(initiatorEmails);
+        }
+
+        return this;
+    }
+
+    public ProcessFindOptions setInitiatorEmail(String initiatorEmail) {
+        Objects.requireNonNull(initiatorEmail, "'initiatorEmail' is required");
+
+        return this.setInitiatorEmails(List.of(initiatorEmail));
+    }
+
+    public ProcessFindOptions addInitiatorEmail(String initiatorEmail) {
+        Objects.requireNonNull(initiatorEmail, "'initiatorEmail' is required");
+        if (!this.initiatorEmails.contains(initiatorEmail)) {
+            this.initiatorEmails.add(initiatorEmail);
+        }
+
+        return this;
+    }
+
+    public ProcessFindOptions removeInitiatorEmail(String initiatorEmail) {
+        Objects.requireNonNull(initiatorEmail, "'initiatorEmail' is required");
+        this.initiatorEmails.remove(initiatorEmail);
 
         return this;
     }

--- a/kuflow-rest/src/main/java/com/kuflow/rest/operation/ProcessOperations.java
+++ b/kuflow-rest/src/main/java/com/kuflow/rest/operation/ProcessOperations.java
@@ -41,6 +41,7 @@ import com.kuflow.rest.model.ProcessEntityUpdateParams;
 import com.kuflow.rest.model.ProcessFindOptions;
 import com.kuflow.rest.model.ProcessMetadataUpdateParams;
 import com.kuflow.rest.model.ProcessPage;
+import com.kuflow.rest.model.ProcessState;
 import com.kuflow.rest.model.ProcessUserActionDocumentUploadParams;
 import java.util.List;
 import java.util.Objects;
@@ -85,6 +86,9 @@ public class ProcessOperations {
         List<UUID> tenantId = !options.getTenantIds().isEmpty() ? options.getTenantIds() : null;
         List<UUID> processDefinitionId = !options.getProcessDefinitionIds().isEmpty() ? options.getProcessDefinitionIds() : null;
         List<String> processDefinitionCode = !options.getProcessDefinitionCodes().isEmpty() ? options.getProcessDefinitionCodes() : null;
+        List<ProcessState> state = !options.getStates().isEmpty() ? options.getStates() : null;
+        List<UUID> initiatorId = !options.getInitiatorIds().isEmpty() ? options.getInitiatorIds() : null;
+        List<String> initiatorEmail = !options.getInitiatorEmails().isEmpty() ? options.getInitiatorEmails() : null;
         List<String> metadata = !options.getMetadata().isEmpty() ? options.getMetadata() : null;
 
         return this.service.findProcessesWithResponse(
@@ -94,6 +98,9 @@ public class ProcessOperations {
             tenantId,
             processDefinitionId,
             processDefinitionCode,
+            state,
+            initiatorId,
+            initiatorEmail,
             metadata,
             context
         );

--- a/kuflow-rest/src/test/java/com/kuflow/rest/operation/ProcessOperationTest.java
+++ b/kuflow-rest/src/test/java/com/kuflow/rest/operation/ProcessOperationTest.java
@@ -137,6 +137,29 @@ public class ProcessOperationTest extends AbstractOperationTest {
     }
 
     @Test
+    @DisplayName("GIVEN state and initiator filters WHEN list processes THEN the query parameters are sent")
+    public void givenStateAndInitiatorFiltersWhenListProcessesThenTheQueryParametersAreSent() {
+        UUID initiatorId = UUID.randomUUID();
+
+        givenThat(
+            get(urlPathEqualTo("/v2024-06-14/processes"))
+                .withQueryParam("state", equalTo("RUNNING"))
+                .withQueryParam("state", equalTo("COMPLETED"))
+                .withQueryParam("initiatorId", equalTo(initiatorId.toString()))
+                .withQueryParam("initiatorEmail", equalTo("jdoe@example.com"))
+                .willReturn(ok().withHeader("Content-Type", "application/json").withBodyFile("processes-api.list.ok.json"))
+        );
+
+        ProcessFindOptions options = new ProcessFindOptions()
+            .addState(ProcessState.RUNNING)
+            .addState(ProcessState.COMPLETED)
+            .addInitiatorId(initiatorId)
+            .addInitiatorEmail("jdoe@example.com");
+
+        this.kuFlowRestClient.getProcessOperations().findProcesses(options);
+    }
+
+    @Test
     @DisplayName("GIVEN an authenticated user WHEN retrieve processes THEN body is parsed correctly")
     public void givenAnAuthenticatedUserWhenRetrieveProcessesThenBodyIsParsedCorrectly() {
         UUID processId = UUID.fromString("80d8c9a1-e3d2-4c35-a0a9-77ec21d28950");

--- a/kuflow-temporal-activity-kuflow/src/main/java/com/kuflow/temporal/activity/kuflow/KuFlowActivitiesImpl.java
+++ b/kuflow-temporal-activity-kuflow/src/main/java/com/kuflow/temporal/activity/kuflow/KuFlowActivitiesImpl.java
@@ -218,6 +218,9 @@ public class KuFlowActivitiesImpl implements KuFlowActivities {
                 .setTenantIds(request.getTenantIds())
                 .setProcessDefinitionIds(request.getProcessDefinitionIds())
                 .setProcessDefinitionCodes(request.getProcessDefinitionCodes())
+                .setStates(request.getStates())
+                .setInitiatorIds(request.getInitiatorIds())
+                .setInitiatorEmails(request.getInitiatorEmails())
                 .setMetadata(request.getMetadata());
 
             ProcessPage processes = this.processOperations.findProcesses(options);

--- a/kuflow-temporal-activity-kuflow/src/main/java/com/kuflow/temporal/activity/kuflow/model/ProcessFindRequest.java
+++ b/kuflow-temporal-activity-kuflow/src/main/java/com/kuflow/temporal/activity/kuflow/model/ProcessFindRequest.java
@@ -25,6 +25,7 @@ package com.kuflow.temporal.activity.kuflow.model;
 
 import static java.util.Collections.unmodifiableList;
 
+import com.kuflow.rest.model.ProcessState;
 import com.kuflow.rest.util.SearchCriteriaUtils;
 import com.kuflow.temporal.common.model.AbstractModel;
 import java.util.LinkedList;
@@ -54,6 +55,21 @@ public class ProcessFindRequest extends AbstractModel {
      * Filter by process definition codes.
      */
     private final List<String> processDefinitionCodes = new LinkedList<>();
+
+    /**
+     * Filter by an array of process states.
+     */
+    private final List<ProcessState> states = new LinkedList<>();
+
+    /**
+     * Filter by an array of initiator ids.
+     */
+    private final List<UUID> initiatorIds = new LinkedList<>();
+
+    /**
+     * Filter by an array of initiator emails.
+     */
+    private final List<String> initiatorEmails = new LinkedList<>();
 
     /**
      * Filter by indexed metadata field values.
@@ -204,6 +220,111 @@ public class ProcessFindRequest extends AbstractModel {
     public ProcessFindRequest removeProcessDefinitionCode(String processDefinitionCode) {
         Objects.requireNonNull(processDefinitionCode, "'processDefinitionCode' is required");
         this.processDefinitionCodes.remove(processDefinitionCode);
+
+        return this;
+    }
+
+    public List<ProcessState> getStates() {
+        return unmodifiableList(this.states);
+    }
+
+    public ProcessFindRequest setStates(List<ProcessState> states) {
+        this.states.clear();
+        if (states != null) {
+            this.states.addAll(states);
+        }
+
+        return this;
+    }
+
+    public ProcessFindRequest setState(ProcessState state) {
+        Objects.requireNonNull(state, "'state' is required");
+
+        return this.setStates(List.of(state));
+    }
+
+    public ProcessFindRequest addState(ProcessState state) {
+        Objects.requireNonNull(state, "'state' is required");
+        if (!this.states.contains(state)) {
+            this.states.add(state);
+        }
+
+        return this;
+    }
+
+    public ProcessFindRequest removeState(ProcessState state) {
+        Objects.requireNonNull(state, "'state' is required");
+        this.states.remove(state);
+
+        return this;
+    }
+
+    public List<UUID> getInitiatorIds() {
+        return unmodifiableList(this.initiatorIds);
+    }
+
+    public ProcessFindRequest setInitiatorIds(List<UUID> initiatorIds) {
+        this.initiatorIds.clear();
+        if (initiatorIds != null) {
+            this.initiatorIds.addAll(initiatorIds);
+        }
+
+        return this;
+    }
+
+    public ProcessFindRequest setInitiatorId(UUID initiatorId) {
+        Objects.requireNonNull(initiatorId, "'initiatorId' is required");
+
+        return this.setInitiatorIds(List.of(initiatorId));
+    }
+
+    public ProcessFindRequest addInitiatorId(UUID initiatorId) {
+        Objects.requireNonNull(initiatorId, "'initiatorId' is required");
+        if (!this.initiatorIds.contains(initiatorId)) {
+            this.initiatorIds.add(initiatorId);
+        }
+
+        return this;
+    }
+
+    public ProcessFindRequest removeInitiatorId(UUID initiatorId) {
+        Objects.requireNonNull(initiatorId, "'initiatorId' is required");
+        this.initiatorIds.remove(initiatorId);
+
+        return this;
+    }
+
+    public List<String> getInitiatorEmails() {
+        return unmodifiableList(this.initiatorEmails);
+    }
+
+    public ProcessFindRequest setInitiatorEmails(List<String> initiatorEmails) {
+        this.initiatorEmails.clear();
+        if (initiatorEmails != null) {
+            this.initiatorEmails.addAll(initiatorEmails);
+        }
+
+        return this;
+    }
+
+    public ProcessFindRequest setInitiatorEmail(String initiatorEmail) {
+        Objects.requireNonNull(initiatorEmail, "'initiatorEmail' is required");
+
+        return this.setInitiatorEmails(List.of(initiatorEmail));
+    }
+
+    public ProcessFindRequest addInitiatorEmail(String initiatorEmail) {
+        Objects.requireNonNull(initiatorEmail, "'initiatorEmail' is required");
+        if (!this.initiatorEmails.contains(initiatorEmail)) {
+            this.initiatorEmails.add(initiatorEmail);
+        }
+
+        return this;
+    }
+
+    public ProcessFindRequest removeInitiatorEmail(String initiatorEmail) {
+        Objects.requireNonNull(initiatorEmail, "'initiatorEmail' is required");
+        this.initiatorEmails.remove(initiatorEmail);
 
         return this;
     }


### PR DESCRIPTION
## Summary

Adds `state`, `initiatorId` and `initiatorEmail` filters to the process find
operation, both in the REST client (`ProcessFindOptions`) and in the Temporal
activity model (`ProcessFindRequest`). Backed by a bump of the pinned KuFlow
OpenAPI spec commit, which exposes the new query parameters.

Closes #169

## Key changes

- **kuflow-rest/openapi/readme.md**: bump the pinned OpenAPI spec commit to
  `c1299210be90059311601adf9260de556ecdfe6e`.
- **Regenerated `ProcessOperationsImpl`**: `findProcesses*` now accept
  `List<ProcessState> state`, `List<UUID> initiatorId` and
  `List<String> initiatorEmail`, sent as repeated query parameters.
- **`ProcessFindOptions`**: new `states`, `initiatorIds` and `initiatorEmails`
  filters, each with the existing collection-accessor pattern
  (`get`/`set<Plural>`/`set<Singular>`/`add`/`remove`), keeping fluent chaining
  and defensive copies.
- **`ProcessOperations.findProcesses`**: forwards the three new filters,
  passing `null` when the corresponding list is empty (same convention as
  `metadata`).
- **`ProcessFindRequest`** (activity model): mirrors the same three filters, and
  **`KuFlowActivitiesImpl.findProcesses`** maps them onto `ProcessFindOptions`.

The public `ProcessOperations.findProcesses(ProcessFindOptions)` signature is
unchanged, so this is a backwards-compatible addition for SDK consumers.

## Testing

- New WireMock test in `ProcessOperationTest`
  (`GIVEN state and initiator filters WHEN list processes THEN the query
  parameters are sent`) asserting the filters reach the request as query
  parameters.
- `./mvnw test -pl kuflow-rest -Dtest=ProcessOperationTest` → passing; the
  request log confirms
  `?state=…&state=…&initiatorId=…&initiatorEmail=…`.
